### PR TITLE
Change rayTracing: selection of rays and calculation of rad depth

### DIFF
--- a/matRad_rayTracing.m
+++ b/matRad_rayTracing.m
@@ -113,46 +113,45 @@ rotMx_XZ_T = [cosd(stf.couchAngle) 0 -sind(stf.couchAngle);
 % rotate ray matrix from bev to world coordinates
 rayMx_world = rayMx_bev * rotMx_XY_T * rotMx_XZ_T;
 
-% set up distance cube to decide which rad depths should be stored
-metricHitVoxelsCube = -inf*ones(size(ct.cube));
+% criterium for ray selection
+raySelection = rayMxSpacing/2;
 
 % perform ray tracing over all rays
 for j = 1:size(rayMx_world,1)
 
     % run siddon ray tracing algorithm
-    [alphas,l,rho,d12,ixHitVoxel] = matRad_siddonRayTracer(stf.isoCenter, ...
+    [~,l,rho,~,ixHitVoxel] = matRad_siddonRayTracer(stf.isoCenter, ...
                                 ct.resolution, ...
                                 stf.sourcePoint, ...
                                 rayMx_world(j,:), ...
                                 {ct.cube});
                                                         
-    % find voxels for which we should remember this tracing because this is
-    % the closest ray
-    normRayVector = rayMx_world(j,:) - stf.sourcePoint;
-    normRayVector = normRayVector/norm(normRayVector);
+    % find voxels for which we should remember this tracing because this is    
+    % the closest ray by projecting the voxel coordinates to the
+    % intersection points with the ray matrix and checking if the distance 
+    % in x and z direction is smaller than the resolution of the ray matrix
+    scale_factor = (rayMx_bev_y + stf.SAD) ./ ...
+                   (coords_bev(ixHitVoxel,2) + stf.SAD);
 
-    dotProdHitVoxels = coords(ixHitVoxel,:)*normRayVector';
-    
-    ixRememberFromCurrTracing = dotProdHitVoxels > metricHitVoxelsCube(ixHitVoxel)';
+    x_dist = coords_bev(ixHitVoxel,1).*scale_factor - rayMx_bev(j,1);
+    z_dist = coords_bev(ixHitVoxel,3).*scale_factor - rayMx_bev(j,3);
+
+    ixRememberFromCurrTracing = x_dist > -raySelection & x_dist <= raySelection ...
+                              & z_dist > -raySelection & z_dist <= raySelection;
 
     if any(ixRememberFromCurrTracing) > 0
-        
-        metricHitVoxelsCube(ixHitVoxel(ixRememberFromCurrTracing)) = dotProdHitVoxels(ixRememberFromCurrTracing);
-
-        % calc radioloical depths
+        % calc radiological depths
 
         % eq 14
         % It multiply voxel intersections with \rho values.
-        % The zero it is neccessary for stability purpose.
-        d = [0 l .* rho{1}]; %Note. It is not a number "one"; it is the letter "l"
+        d =l .* rho{1}; %Note. It is not a number "one"; it is the letter "l"
 
         % Calculate accumulated d sum.
-        dCum = cumsum(d);
-
-        % Calculate the radiological path
-        vRadDepth = interp1(alphas,dCum,dotProdHitVoxels(ixRememberFromCurrTracing)/d12,'linear',0);
-             
-        radDepthCube(ixHitVoxel(ixRememberFromCurrTracing)) = vRadDepth;
+        dCum = cumsum(d)-d/2;
+       
+        % write radiological depth for voxel which we want to remember
+        radDepthCube(ixHitVoxel(ixRememberFromCurrTracing))= dCum(ixRememberFromCurrTracing);
+        
     end
     
 end


### PR DESCRIPTION
Selection of rays through extrapolating the intersection points of candidates with the ray matrix and dismissing all with x/z distance greater than half the resolution of the ray matrix.

Calculation of the radiological path without interpolation by adding half of the length traversed through the voxel times the relative electron density.