### PR TITLE
Bugfix in matRadGUI. Per default the cube with filename 'physicalDose…

### DIFF
--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -777,9 +777,11 @@ end
 
 %% plot dose cube
 if handles.State >2 &&  get(handles.popupTypeOfPlot,'Value')== 1
-
+        % if the selected display option doesn't exist then simply display
+        % the first cube of the Result struct
         if ~isfield(Result,handles.SelectedDisplayOption)
-            handles.SelectedDisplayOption = 'physicalDose';
+            CubeNames = fieldnames(Result);
+            handles.SelectedDisplayOption = CubeNames{1,1};
         end
         mVolume = getfield(Result,handles.SelectedDisplayOption);
         % make sure to exploit full color range 


### PR DESCRIPTION
Bugfix in matRadGUI. Per default the cube with filename 'physicalDose is plotted. If that exact filename doesn't exist then plot now as fallback the first cube on startup.