### PR TITLE
DICOM IMPORT: replaced grid vectors in cube interpolation with meshgrids

### DIFF
--- a/dicomImport/matRad_importDicom.m
+++ b/dicomImport/matRad_importDicom.m
@@ -95,7 +95,9 @@ end
 
 %% import dose cube
 if isfield(files,'rtdose')
-    if ~(cellfun(@isempty,files.rtdose(1,:)))
+    % check if files.rtdose contains a path and is labeld as RTDose
+    % only the first two elements are relevant for loading the rt dose
+    if ~(cellfun(@isempty,files.rtdose(1,1:2))) 
         fprintf('loading Dose files \n', structures(i).structName);
         resultGUI = matRad_importDicomRTDose(ct, files.rtdose);
         if size(resultGUI) == 0

--- a/dicomImport/matRad_interpDicomCtCube.m
+++ b/dicomImport/matRad_interpDicomCtCube.m
@@ -37,22 +37,28 @@ coordsOfFirstPixel = [origCtInfo.ImagePositionPatient];
 
 % set up grid vectors
 x = coordsOfFirstPixel(1,1) + origCtInfo(1).PixelSpacing(1)*double([0:origCtInfo(1).Columns-1]);
-y = coordsOfFirstPixel(2,1) + origCtInfo(1).PixelSpacing(2)*double([0:origCtInfo(1).Rows-1]');
+y = coordsOfFirstPixel(2,1) + origCtInfo(1).PixelSpacing(2)*double([0:origCtInfo(1).Rows-1]);
 z = coordsOfFirstPixel(3,:);
 
-xi = coordsOfFirstPixel(1,1):resolution.x:(coordsOfFirstPixel(1,1)+origCtInfo(1).PixelSpacing(1)*double(origCtInfo(1).Rows-1));
-yi = [coordsOfFirstPixel(2,1):resolution.y:(coordsOfFirstPixel(2,1)+origCtInfo(1).PixelSpacing(2)*double(origCtInfo(1).Columns-1))]';
-zi = coordsOfFirstPixel(3,1):resolution.z: coordsOfFirstPixel(3,end);
+xq = coordsOfFirstPixel(1,1):resolution.x:(coordsOfFirstPixel(1,1)+origCtInfo(1).PixelSpacing(1)*double(origCtInfo(1).Columns-1));
+yq = [coordsOfFirstPixel(2,1):resolution.y:(coordsOfFirstPixel(2,1)+origCtInfo(1).PixelSpacing(2)*double(origCtInfo(1).Rows-1))];
+zq = coordsOfFirstPixel(3,1):resolution.z: coordsOfFirstPixel(3,end);
 
-% interpolate
-interpCt.cube{1} = interp3(x,y,z,origCt,xi,yi,zi);
+% set up grid matrices - implicit dimension permuation (X Y Z-> Y X Z)
+% Matlab represents internally in the first matrix dimension the
+% ordinate axis and in the second matrix dimension the abscissas axis
+[ Y,  X,  Z] = meshgrid(x,y,z);
+[Yq, Xq, Zq] = meshgrid(xq,yq,zq);
+
+% interpolate cube - cube is now stored in Y X Z 
+interpCt.cube{1} = interp3(Y,X,Z,origCt,Yq,Xq,Zq);
 
 % some meta information
 interpCt.resolution = resolution;
 
-interpCt.x = xi;
-interpCt.y = yi';
-interpCt.z = zi;
+interpCt.x = xq;
+interpCt.y = yq;
+interpCt.z = zq;
 
-interpCt.cubeDim     = [numel(yi) numel(xi) numel(zi)];
+interpCt.cubeDim     = [numel(yq) numel(xq) numel(zq)];
 interpCt.numOfCtScen = 1;

--- a/dicomImport/matRad_interpDicomDoseCube.m
+++ b/dicomImport/matRad_interpDicomDoseCube.m
@@ -58,13 +58,19 @@ dose.cube = squeeze(dosedata(:,:,1,:));
 
 % generating grid vectors
 x = doseInfo.ImagePositionPatient(1) + doseInfo.PixelSpacing(1) * double([0:doseInfo.Columns - 1]);
-y = doseInfo.ImagePositionPatient(2) + doseInfo.PixelSpacing(2) * double([0:doseInfo.Rows - 1])';
-z = [doseInfo.ImagePositionPatient(3) + doseInfo.GridFrameOffsetVector]';
+y = doseInfo.ImagePositionPatient(2) + doseInfo.PixelSpacing(2) * double([0:doseInfo.Rows - 1]);
+z = [doseInfo.ImagePositionPatient(3) + doseInfo.GridFrameOffsetVector];
 
 % new vectors
 xq = [min(ct.x) : target_resolution.x : max(ct.x)];
-yq = [min(ct.y) : target_resolution.y : max(ct.y)]';
+yq = [min(ct.y) : target_resolution.y : max(ct.y)];
 zq =  min(ct.z) : target_resolution.z : max(ct.z);
+
+% set up grid matrices - implicit dimension permuation (X Y Z-> Y X Z)
+% Matlab represents internally in the first matrix dimension the
+% ordinate axis and in the second matrix dimension the abscissas axis
+[ Y,  X,  Z] = meshgrid(x,y,z);
+[Yq, Xq, Zq] = meshgrid(xq,yq,zq);
 
 % scale cube from relative (normalized) to absolute values
 % need BitDepth
@@ -76,13 +82,13 @@ doseScale = (2 ^ bitDepth - 1) * gridScale;
 % rescale dose.cube
 dose.cube = doseScale * dose.cube;
 
-% interpolation to ct grid
-dose.cube = interp3(x,y,z,dose.cube,xq,yq,zq,'linear',0);
+% interpolation to ct grid - cube is now stored in Y X Z
+dose.cube = interp3(Y,X,Z,dose.cube,Yq,Xq,Zq,'linear',0);
 
 % write new parameters
 dose.resolution = ct.resolution;
 dose.x = xq;
-dose.y = yq';
+dose.y = yq;
 dose.z = zq;
 
 % check whether grid position are the same as the CT grid positions are


### PR DESCRIPTION
Notation is consistent with matRad. Cubes are stored in the following order Y X Z