### PR TITLE
Change weights to fraction based value and try to rescale dose cubes

### DIFF
--- a/dicomImport/matRad_importDicom.m
+++ b/dicomImport/matRad_importDicom.m
@@ -99,13 +99,19 @@ if isfield(files,'rtdose')
     % only the first two elements are relevant for loading the rt dose
     if ~(cellfun(@isempty,files.rtdose(1,1:2))) 
         fprintf('loading Dose files \n', structures(i).structName);
-        resultGUI = matRad_importDicomRTDose(ct, files.rtdose);
+        % parse plan in order to scale dose cubes to a fraction based dose
+        if exist('pln','var')
+            if isfield(pln,'numOfFractions')
+                resultGUI = matRad_importDicomRTDose(ct, files.rtdose, pln);
+            end
+        else
+            resultGUI = matRad_importDicomRTDose(ct, files.rtdose);
+        end
         if size(resultGUI) == 0
            clear resultGUI;
         end
     end
 end
-
 
 %% put weight also into resultGUI
 if exist('stf','var') && exist('resultGUI','var')

--- a/dicomImport/matRad_importDicomRTDose.m
+++ b/dicomImport/matRad_importDicomRTDose.m
@@ -1,4 +1,4 @@
-function [ resultGUI ] = matRad_importDicomRTDose(ct, rtDoseFiles)
+function [ resultGUI ] = matRad_importDicomRTDose(ct, rtDoseFiles, pln)
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % matRad function to import dicom RTDOSE data
 % 
@@ -61,6 +61,11 @@ for i = 1 : numDoseFiles
         resultName = 'physicalDose';
     elseif strncmpi(resultName,'RBExDose_PLAN',10)
         resultName = 'RBExDose';
+    end
+    
+    % scale to fraction based dose
+    if exist('pln','var')
+        dose.(itemName).cube = dose.(itemName).cube / pln.numOfFractions;
     end
     
     resultGUI.(resultName) = dose.(itemName).cube;

--- a/dicomImport/matRad_importDicomSteering.m
+++ b/dicomImport/matRad_importDicomSteering.m
@@ -168,7 +168,7 @@ for i = 1:length(BeamSeqNames)
         k = ic(j);
         stf(i).ray(k).energy = [stf(i).ray(k).energy double(StfTmp(j,3))];
         stf(i).ray(k).focusFWHM = [stf(i).ray(k).focusFWHM double(StfTmp(j,5))];
-        stf(i).ray(k).weight = [stf(i).ray(k).weight double(StfTmp(j,4))/1e6*pln.numOfFractions];
+        stf(i).ray(k).weight = [stf(i).ray(k).weight double(StfTmp(j,4)) / 1e6];
     end
     
     


### PR DESCRIPTION
I'd recommend to store the weights per fraction (as it is in DICOM) and scale dose cubes to dose per fraction (as it is _not_ in DICOM RTDOSE). This would be according to the usual matRad behaviour?