### PR TITLE
Visualization of the Overlap Priorities on the CT

### DIFF
--- a/matRad_calcCubes.m
+++ b/matRad_calcCubes.m
@@ -34,19 +34,13 @@ if nargin < 4
     scenNum = 1;
 end
 
-% consider VOI priorities
-cst  = matRad_setOverlapPriorities(cst);
-
 resultGUI.w = w;
 
 % calc dose and reshape from 1D vector to 2D array
 resultGUI.physicalDose = reshape(dij.physicalDose{scenNum}*resultGUI.w,dij.dimensions);
 
-%Calculate Overlap Cube
-resultGUI.overlapCube = zeros(size(resultGUI.physicalDose));
-for i = 1:size(cst,1)
-   resultGUI.overlapCube(cst{i,4}{1}) = cst{i,5}.Priority;
-end 
+% consider VOI priorities
+[cst,resultGUI.overlapCube]  = matRad_setOverlapPriorities(cst,size(resultGUI.physicalDose));
 
 if isfield(dij,'mAlphaDose') && isfield(dij,'mSqrtBetaDose')
 

--- a/matRad_calcCubes.m
+++ b/matRad_calcCubes.m
@@ -40,7 +40,7 @@ resultGUI.w = w;
 resultGUI.physicalDose = reshape(dij.physicalDose{scenNum}*resultGUI.w,dij.dimensions);
 
 % consider VOI priorities
-[cst,resultGUI.overlapCube]  = matRad_setOverlapPriorities(cst,size(resultGUI.physicalDose));
+[cst,resultGUI.overlapCube]  = matRad_setOverlapPriorities(cst,dij.dimensions);
 
 if isfield(dij,'mAlphaDose') && isfield(dij,'mSqrtBetaDose')
 

--- a/matRad_calcCubes.m
+++ b/matRad_calcCubes.m
@@ -42,6 +42,12 @@ resultGUI.w = w;
 % calc dose and reshape from 1D vector to 2D array
 resultGUI.physicalDose = reshape(dij.physicalDose{scenNum}*resultGUI.w,dij.dimensions);
 
+%Calculate Overlap Cube
+resultGUI.overlapCube = zeros(size(resultGUI.physicalDose));
+for i = 1:size(cst,1)
+   resultGUI.overlapCube(cst{i,4}{1}) = cst{i,5}.Priority;
+end 
+
 if isfield(dij,'mAlphaDose') && isfield(dij,'mSqrtBetaDose')
 
     a_x = zeros(size(resultGUI.physicalDose));

--- a/matRad_setOverlapPriorities.m
+++ b/matRad_setOverlapPriorities.m
@@ -1,4 +1,4 @@
-function cst = matRad_setOverlapPriorities(cst)
+function [cst,overlapPriorityCube] = matRad_setOverlapPriorities(cst,ctDim)
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % function to handle overlap priorities during fluence optimizaiton and
 % dose calculation. If you have overlapping volumes of interest you need to
@@ -6,12 +6,15 @@ function cst = matRad_setOverlapPriorities(cst)
 % 
 % call
 %   cst = matRad_considerOverlap(cst)
+%   [cst, overlapPriorityCube] = matRad_setOverlapPriorities(cst,cubeDim)
 %
 % input
 %   cst:        cst file
+%   ctDim:      dimension of the ct for overlap cube claculation (optional)
 %
 % output
-%   cst:    updated cst file considering overlap priorities
+%   cst:                updated cst file considering overlap priorities
+%   overlapPriorityCube cube visualizing the overlap priority (optional)
 %
 % References
 %   -
@@ -35,7 +38,7 @@ numOfCtScenarios = unique(cellfun(@(x)numel(x),cst(:,4)));
 
 if numel(numOfCtScenarios) > 1
     error('Inconsistent number of segmentations in cst struct.');
-end
+end  
 
 for i = 1:numOfCtScenarios
     
@@ -61,6 +64,15 @@ for i = 1:numOfCtScenarios
          
     end
 end
+
+%Calculate the overlap cube if requested
+if nargout == 2 && nargin == 2
+   overlapPriorityCube = zeros(ctDim);
+    for i = 1:size(cst,1)
+        overlapPriorityCube(cst{i,4}{1}) = cst{i,5}.Priority;
+    end
+end
+    
 
 end
 


### PR DESCRIPTION
This small feature calculates the exclusive overlap priority cube from the cst information and puts it into resultGUI, and can be thus selected for displaying in the drop down menu
In the past found it quite useful to be able to take a look at those directly on the CT.