### PR TITLE
*bugfix in dij sampling algorithm for photons

### DIFF
--- a/matRad_DijSampling.m
+++ b/matRad_DijSampling.m
@@ -42,8 +42,8 @@ function [ixNew,bixelDoseNew] =  matRad_DijSampling(ix,bixelDose,radDepthV,rad_d
 %% define default parameters as a fallback 
 defaultType                = 'radius';
 deltaRadDepth              = 5;                       % step size of radiological depth
-defaultLatCutOff           = 25;
-defaultrelDoseThreshold    = 0.01;                    % equals to 1%
+defaultLatCutOff           = 25;                      % default lateral cut off
+defaultrelDoseThreshold    = 0.01;                    % default relative dose threshold
 
 relDoseThreshold           = defaultrelDoseThreshold;
 LatCutOff                  = defaultLatCutOff;

--- a/matRad_DijSampling.m
+++ b/matRad_DijSampling.m
@@ -10,7 +10,12 @@ function [ixNew,bixelDoseNew] =  matRad_DijSampling(ix,bixelDose,radDepthV,rad_d
 %   bixelDose:        dose at specified locations as linear vector
 %   radDepthV:        radiological depth vector
 %   rad_distancesSq:  squared radial distance to the central ray
-%   r0:               dose values having a radial distance below r0 are keept anyway. sampling is only done beyond r0. 
+%   sType:            can either be set to 'radius' or 'dose'. These are two different ways 
+%                     to determine dose values that are keept as they are and dose values used for sampling
+%   Param:            In the case of radius based sampling, dose values having a radial 
+%                     distance below r0 [mm] are keept anyway and sampling is only done beyond r0. 
+%                     In the case of dose based sampling, dose values having a relative dose greater 
+%                     the threshold [0...1] are keept and sampling is done for dose values below the relative threshold  
 %
 % output
 %   ixNew:            reduced indices of voxels where we want to compute dose influence data

--- a/matRad_DijSampling.m
+++ b/matRad_DijSampling.m
@@ -1,21 +1,20 @@
-function [ix,bixelDose] =  matRad_DijSampling(ix,bixelDose,relDoseLimits,SamplingRate)
+function [ixNew,bixelDoseNew] =  matRad_DijSampling(ix,bixelDose,radDepthV,rad_distancesSq,r0)
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % matRad dij sampling function. This function samples 
 % 
 % call
-%   [ix,bixelDose] =  matRad_DijImportanceSampling(ix,bixelDose,relDoseLimits)
+%   [ixNew,bixelDoseNew] =  matRad_DijSampling(ix,bixelDose,radDepthV,rad_distancesSq,25)
 %
 % input
-%   ix:             indices of voxels where we want to compute dose influence data
-%   bixelDose:      dose at specified locations as linear vector
-%   relDoseLimits:  relative dose levels used to define sampling range 
-%                   e.g.[0.01 0.001] means that dij elements will be
-%                   sampled in the relative dose range 1%-0.1%
-
+%   ix:               indices of voxels where we want to compute dose influence data
+%   bixelDose:        dose at specified locations as linear vector
+%   radDepthV:        radiological depth vector
+%   rad_distancesSq:  squared radial distance to the central ray
+%   r0:               dose values having a radial distance below r0 are keept anyway. sampling is only done beyond r0. 
 %
 % output
-%   ix:             reduced indices of voxels where we want to compute dose influence data
-%   bixelDose       reduced dose at specified locations as linear vector
+%   ixNew:            reduced indices of voxels where we want to compute dose influence data
+%   bixelDoseNew      reduced dose at specified locations as linear vector
 %
 % References
 %   [1] http://dx.doi.org/10.1118/1.1469633
@@ -35,25 +34,74 @@ function [ix,bixelDose] =  matRad_DijSampling(ix,bixelDose,relDoseLimits,Samplin
 %
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-if ~exist('SamplingRate','var')
-    SamplingRate       = 0.1;
+boolFineClustering  = false;                                     % flag to switch between fine and coarse radiological depth resolution
+deltaRadDepth       = 4;                                         % step size of radiological depth
+LatCutOffsq         = r0^2;
+
+%% remember dose values inside the inner core
+ixCore              = rad_distancesSq < LatCutOffsq;             % get voxels indices having a smaller radial distance than r0
+bixelDoseCore       = bixelDose(ixCore);                         % save dose values that are not affected by sampling
+
+ixTail              = ~ixCore;                                   % get voxels indices beyond r0
+linIxSample         = find(ixTail);                              % convert logical index to linear index
+numTail             = numel(linIxSample);
+bixelDoseTail       = bixelDose(linIxSample);                    % dose values that are going to be reduced by sampling
+ixSampTail          = ix(linIxSample);                           % indices that are going to be reduced by sampling
+
+%% sample for each radiological depth the lateral halo dose  
+radDepthTail        = (radDepthV(linIxSample));                  % get radiological depth in the tail
+
+% cluster radiological dephts to reduce computations
+B_r                 = int32(ceil(radDepthTail));                 % cluster radiological depths; hist(B,NumOfClusters) could also be used
+if boolFineClustering 
+    [C,~,~]   = unique(B_r);                                                         % get unique radiological depht values == fine clustering
+else 
+     maxRadDepth = double(max(B_r));
+     C           = int32(linspace(0,maxRadDepth,round(maxRadDepth)/deltaRadDepth));        % coarse clustering of rad depths    
 end
 
-maxDose            = max(bixelDose);
-linIxSample        = find(bixelDose < maxDose * relDoseLimits(1) & bixelDose > maxDose * relDoseLimits(2));
-NumSamples         = fix(numel(linIxSample)*SamplingRate);
-bixelSampDose      = bixelDose(linIxSample);
-Prob               = bixelSampDose/max(bixelSampDose);
-ProbNorm           = sort(Prob,'descend')./(sum(Prob));
-CDF                = cumsum(ProbNorm);
-randomValues       = (CDF(end)-CDF(1)).* rand(NumSamples,1) + CDF(1);
-ixSamp             = interp1(CDF,linIxSample,randomValues,'nearest');
-ixNew              = (bixelDose > maxDose * relDoseLimits(1)) ;
-ixNew(ixSamp)      = 1;
-bixelDose(ixSamp)  = maxDose * relDoseLimits(1);
-bixelDose          = bixelDose(ixNew);
-ix                 = ix(ixNew);
+ixNew               = zeros(numTail,1);                          % inizialize new index vector
+bixelDoseNew        = zeros(numTail,1);                          % inizialize new dose vector
+IxCnt               = 1;
+linIx               = int32(1:1:numTail)';
 
+% loop over clustered radiological depths
+for i = 1:numel(C)-1
 
+    ixTmp              = linIx(B_r >= C(i) & B_r < C(i+1));                        % extracting sub indices
+    if isempty(ixTmp)
+        continue
+    end
+    subDose            = bixelDoseTail(ixTmp);
+    subIx              = ixSampTail(ixTmp);
+    
+    thresholdDose      = max(subDose);
+    NumSamples         = round(sum(subDose)/thresholdDose);   
+    [Prob,ixSort]      = sort(subDose/thresholdDose,'descend');                    % get probability 
+    ProbNorm           = (Prob)./(sum(Prob));                                      % get normalized probability  
+    subIx              = subIx(ixSort);
+    CDF                = cumsum(ProbNorm);                                         % calculate cummlative probability density 
+    
+    if numel(CDF) ~= 1
+        % take random samples from an arbritrary pdf
+        randomValues       = (CDF(end)-CDF(1)).* rand(NumSamples,1) + CDF(1);      % sample random positions
+        ixSamp  = interp1(CDF,1:numel(Prob),randomValues,'nearest');               % convert random samples to linear indices 
+        %ixSamp  = sum(bsxfun(@le,CDF,randomValues'))';      
+    else
+        ixSamp  = 1;
+    end
 
+    ixNew(IxCnt:IxCnt+NumSamples-1,1)        = subIx(ixSamp);
+    bixelDoseNew(IxCnt:IxCnt+NumSamples-1,1) = thresholdDose;
+    
+    IxCnt = IxCnt + NumSamples;
+end
 
+% cut the vectors
+ixNew        = ixNew(1:IxCnt-1);
+bixelDoseNew = bixelDoseNew(1:IxCnt-1);
+% add inner core values  
+ixNew        = [ix(ixCore); ixNew];
+bixelDoseNew = [bixelDoseCore; bixelDoseNew];
+
+end

--- a/matRad_calcParticleDose.m
+++ b/matRad_calcParticleDose.m
@@ -157,7 +157,7 @@ end
 fprintf('matRad: Particle dose calculation...\n');
 counter = 0;
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-for i = 1:dij.numOfBeams; % loop over all beams
+for i = 1:dij.numOfBeams % loop over all beams
     
     fprintf(['Beam ' num2str(i) ' of ' num2str(dij.numOfBeams) ': \n']);
 
@@ -203,7 +203,7 @@ for i = 1:dij.numOfBeams; % loop over all beams
     
     % Determine lateral cutoff
     fprintf('matRad: calculate lateral cutoff...');
-    cutOffLevel = .99;
+    cutOffLevel = .9975;
     visBoolLateralCutOff = 0;
     machine = matRad_calcLateralParticleCutOff(machine,cutOffLevel,stf(i),visBoolLateralCutOff);
     fprintf('done.\n');    
@@ -281,6 +281,12 @@ for i = 1:dij.numOfBeams; % loop over all beams
                     stf(i).ray(j).SSD, ...
                     stf(i).ray(j).focusIx(k), ...
                     machine.data(energyIx)); 
+                
+  
+                relDoseThreshold   =  0.02;   % sample dose values beyond the relative dose
+                Type               = 'dose';
+                [currIx,bixelDose] = matRad_DijSampling(currIx,bixelDose,radDepths(currIx),radialDist_sq(currIx),Type,relDoseThreshold);
+
                 
                 % Save dose for every bixel in cell array
                 doseTmpContainer{mod(counter-1,numOfBixelsContainer)+1,1} = sparse(V(ix(currIx)),1,bixelDose,dij.numOfVoxels,1);

--- a/matRad_calcParticleDose.m
+++ b/matRad_calcParticleDose.m
@@ -203,7 +203,7 @@ for i = 1:dij.numOfBeams % loop over all beams
     
     % Determine lateral cutoff
     fprintf('matRad: calculate lateral cutoff...');
-    cutOffLevel = .9975;
+    cutOffLevel = .99;
     visBoolLateralCutOff = 0;
     machine = matRad_calcLateralParticleCutOff(machine,cutOffLevel,stf(i),visBoolLateralCutOff);
     fprintf('done.\n');    
@@ -283,9 +283,10 @@ for i = 1:dij.numOfBeams % loop over all beams
                     machine.data(energyIx)); 
                 
   
-                relDoseThreshold   =  0.02;   % sample dose values beyond the relative dose
-                Type               = 'dose';
-                [currIx,bixelDose] = matRad_DijSampling(currIx,bixelDose,radDepths(currIx),radialDist_sq(currIx),Type,relDoseThreshold);
+                % dij sampling is exluded for particles until we investigated the influence of voxel sampling for particles
+                %relDoseThreshold   =  0.02;   % sample dose values beyond the relative dose
+                %Type               = 'dose';
+                %[currIx,bixelDose] = matRad_DijSampling(currIx,bixelDose,radDepths(currIx),radialDist_sq(currIx),Type,relDoseThreshold);
 
                 
                 % Save dose for every bixel in cell array

--- a/matRad_calcPhotonDose.m
+++ b/matRad_calcPhotonDose.m
@@ -91,7 +91,7 @@ V = unique(vertcat(V{:}));
 [yCoordsV_vox, xCoordsV_vox, zCoordsV_vox] = ind2sub(ct.cubeDim,V);
 
 % set lateral cutoff value
-lateralCutoff = 65; % [mm]
+lateralCutoff = 82; % [mm]
 
 % toggle custom primary fluence on/off. if 0 we assume a homogeneous
 % primary fluence, if 1 we use measured radially symmetric data
@@ -242,7 +242,7 @@ for i = 1:dij.numOfBeams; % loop over all beams
         dij.bixelNum(counter) = j;
         
         % Ray tracing for beam i and bixel j
-        [ix,~,isoLatDistsX,isoLatDistsZ] = matRad_calcGeoDists(rot_coordsV, ...
+        [ix,rad_distancesSq,isoLatDistsX,isoLatDistsZ] = matRad_calcGeoDists(rot_coordsV, ...
                                                                stf(i).sourcePoint_bev, ...
                                                                stf(i).ray(j).targetPoint_bev, ...
                                                                machine.meta.SAD, ...
@@ -262,10 +262,8 @@ for i = 1:dij.numOfBeams; % loop over all beams
 
 
         
-        % Sample dij elements between 1% and 0.1% of the dose                              
-        tolDoseLimits  = [0.01 0.001];
-        SamplingRate   = 0.1;   % sample x% of the voxels within the previously specified range
-        [ix,bixelDose] = matRad_DijSampling(ix,bixelDose,tolDoseLimits,SamplingRate);
+        r0   = 25;   % [mm] sample beyond the inner core
+        [ix,bixelDose] = matRad_DijSampling(ix,bixelDose,radDepthV{1}(ix),rad_distancesSq,r0);
            
         % Save dose for every bixel in cell array
         doseTmpContainer{mod(counter-1,numOfBixelsContainer)+1,1} = sparse(V(ix),1,bixelDose,dij.numOfVoxels,1);

--- a/matRad_calcPhotonDose.m
+++ b/matRad_calcPhotonDose.m
@@ -263,7 +263,8 @@ for i = 1:dij.numOfBeams; % loop over all beams
 
         
         r0   = 25;   % [mm] sample beyond the inner core
-        [ix,bixelDose] = matRad_DijSampling(ix,bixelDose,radDepthV{1}(ix),rad_distancesSq,r0);
+        Type = 'radius';
+        [ix,bixelDose] = matRad_DijSampling(ix,bixelDose,radDepthV{1}(ix),rad_distancesSq,Type,r0);
            
         % Save dose for every bixel in cell array
         doseTmpContainer{mod(counter-1,numOfBixelsContainer)+1,1} = sparse(V(ix),1,bixelDose,dij.numOfVoxels,1);


### PR DESCRIPTION
Dis sampling depends now on the actual radiological depth considering now also the lateral distance.
I am open to inputs/suggestions to improve the sampling performance. The three most expensive lines are 71, 80, and 88. 

Performance on the TG119 phantom using 5 beams:
                                  DIJ-full calculation        |        DIJ-sampling
size:                      |     4.14GB                          |          1.2GB
time dose calc:    |        88s                             |          163s
time opt:               |      130s                             |            30s
total:                     |     218s                              |         193s