### PR TITLE
Fix bug during import of field shapes

### DIFF
--- a/dicomImport/matRad_importDicomSteeringPhotons.m
+++ b/dicomImport/matRad_importDicomSteeringPhotons.m
@@ -28,9 +28,13 @@ function [stf, pln] = matRad_importDicomSteeringPhotons(pln)
 % LICENSE file.
 %
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
+stf = struct;
 % get fields possessing a field weight vector greater than 0
-Fields = pln.Collimation.Fields([pln.Collimation.Fields(:).Weight] > 0);
+if isfield(pln.Collimation,'Fields')
+    Fields = pln.Collimation.Fields([pln.Collimation.Fields(:).Weight] > 0);
+else 
+    return
+end
 
 [UniqueComb,ia,ib] = unique( vertcat([Fields(:).GantryAngle], [Fields(:).CouchAngle])','rows');
 

--- a/dicomImport/matRad_importDicomSteeringPhotons.m
+++ b/dicomImport/matRad_importDicomSteeringPhotons.m
@@ -29,12 +29,12 @@ function [stf, pln] = matRad_importDicomSteeringPhotons(pln)
 %
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 stf = struct;
-% get fields possessing a field weight vector greater than 0
-if isfield(pln.Collimation,'Fields')
-    Fields = pln.Collimation.Fields([pln.Collimation.Fields(:).Weight] > 0);
-else 
+if ~isfield(pln.Collimation,'Fields')
     return
 end
+
+% get fields possessing a field weight vector greater than 0
+Fields = pln.Collimation.Fields([pln.Collimation.Fields(:).Weight] > 0);
 
 [UniqueComb,ia,ib] = unique( vertcat([Fields(:).GantryAngle], [Fields(:).CouchAngle])','rows');
 

--- a/dicomImport/matRad_importFieldShapes.m
+++ b/dicomImport/matRad_importFieldShapes.m
@@ -134,7 +134,7 @@ for i = 1:length(collimation.Fields)
     counter = counter + 1;
     shape = ones(2*convLimits/convResolution); 
     beamIndex = collimation.FieldOfBeam(i).BeamIndex;
-    for j = 1:length(currDeviceSeqNames)
+    for j = 1:length(collimation.Devices{beamIndex})
         % check for ASYM and SYM jaws == type 1
         if strncmpi(collimation.Devices{beamIndex}(j).DeviceType,'ASYM',4)
             type = 1;

--- a/dicomImport/matRad_importFieldShapes.m
+++ b/dicomImport/matRad_importFieldShapes.m
@@ -60,7 +60,7 @@ for i = 1:length(BeamSeqNames)
     end
     collimation.Devices{i} = device;
     
-     currControlPointSeqNames = fieldnames(currBeamSeq.ControlPointSequence);
+    currControlPointSeqNames = fieldnames(currBeamSeq.ControlPointSequence);
     % all meta informations must be defined in the first control point sequence
     % see DICOM Doc Sec. C.8.8.14.5
     % http://dicom.nema.org/MEDICAL/Dicom/2015c/output/chtml/part03/sect_C.8.8.14.5.html
@@ -93,7 +93,7 @@ for i = 1:length(BeamSeqNames)
                             device(k).DeviceType '. No field shape import performed!']);
                    return;
                end
-               collimation.Fields(counter).LeafPos{k} = NaN*ones(device(k).NumOfLeafs,2);
+               % set left and right leaf positions
                collimation.Fields(counter).LeafPos{k}(:,1) = currLeafPos(1:device(k).NumOfLeafs);
                collimation.Fields(counter).LeafPos{k}(:,2) = currLeafPos(device(k).NumOfLeafs+1:end); 
            end

--- a/dicomImport/matRad_importFieldShapes.m
+++ b/dicomImport/matRad_importFieldShapes.m
@@ -29,88 +29,99 @@ function Collimation = matRad_importFieldShapes(BeamSequence, BeamSeqNames)
 % LICENSE file.
 %
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-% get collimator device types 
-DeviceSeq = BeamSequence.(BeamSeqNames{1}).BeamLimitingDeviceSequence;
-DeviceSeqNames = fieldnames(DeviceSeq);
-
-% set device specific parameters
-Collimation.Devices = struct;
-for i = 1:length(DeviceSeqNames)
-    currLimitsSeq = DeviceSeq.(DeviceSeqNames{i});
-    Collimation.Devices(i).DeviceType = currLimitsSeq.RTBeamLimitingDeviceType;
-    Collimation.Devices(i).NumOfLeafs = currLimitsSeq.NumberOfLeafJawPairs;
-    Collimation.Devices(i).Direction = Collimation.Devices(i).DeviceType(length(Collimation.Devices(i).DeviceType)); 
-    if strncmpi(Collimation.Devices(i).DeviceType,'MLC',3)
-       Collimation.Devices(i).Limits = currLimitsSeq.LeafPositionBoundaries; 
-    end
-end
-
-% get all field names
-numOfFields = 0;
-FieldSeqNames{length(BeamSeqNames)} = [];
-for i = 1:length(BeamSeqNames)
-    FieldSeqNames{i} = fieldnames(BeamSequence.(BeamSeqNames{i}).ControlPointSequence);
-    numOfFields = numOfFields + numel(FieldSeqNames{i});
-end
-
-Collimation.numOfFields = numOfFields;
+Collimation = struct;
 
 % check for following meta data in every control point sequence
 % Format: 'DICOM Name Tag' 'Name in struct'; ... 
 meta =  {'NominalBeamEnergy' 'Energy';'GantryAngle' 'GantryAngle';...
         'PatientSupportAngle' 'CouchAngle';'SourceToSurfaceDistance' 'SSD'};
 
-% save information which control point sequence belongs to which beam sequence
-Collimation.FieldOfBeam = NaN * ones(numOfFields,1);
-
 counter = 0;
-Collimation.Fields = struct;
+collimation.Fields = struct;
 % extract field information
 for i = 1:length(BeamSeqNames)
     currBeamSeq = BeamSequence.(BeamSeqNames{i});
     cumWeight = 0;
+    
+    % get collimator device types 
+    currDeviceSeq = BeamSequence.(BeamSeqNames{i}).BeamLimitingDeviceSequence;
+    currDeviceSeqNames = fieldnames(currDeviceSeq);
+    
+    % set device specific parameters
+    device = struct;
+    for j = 1:length(currDeviceSeqNames)
+        currLimitsSeq = currDeviceSeq.(currDeviceSeqNames{j});
+        device(j).DeviceType = currLimitsSeq.RTBeamLimitingDeviceType;
+        device(j).NumOfLeafs = currLimitsSeq.NumberOfLeafJawPairs;
+        device(j).Direction = device(j).DeviceType(end); 
+        if strncmpi(device(j).DeviceType,'MLC',3)
+           device(j).Limits = currLimitsSeq.LeafPositionBoundaries; 
+        end
+    end
+    collimation.Devices{i} = device;
+    
+     currControlPointSeqNames = fieldnames(currBeamSeq.ControlPointSequence);
     % all meta informations must be defined in the first control point sequence
     % see DICOM Doc Sec. C.8.8.14.5
     % http://dicom.nema.org/MEDICAL/Dicom/2015c/output/chtml/part03/sect_C.8.8.14.5.html
     for j = 1:length(meta)
-        FieldMeta.(meta{j,2}) = currBeamSeq.ControlPointSequence.Item_1.(meta{j,1});
+        try
+            FieldMeta.(meta{j,2}) = currBeamSeq.ControlPointSequence.(currControlPointSeqNames{1}).(meta{j,1});
+        catch
+            warning(['Field ' meta{j,1} ' not found on beam sequence ' BeamSeqNames{i} ...
+                     '. No field shape import performed!']);
+            return;
+        end
     end
-    for j = 1:length(FieldSeqNames{i})
-        counter = counter + 1;
-        currFieldSeq = currBeamSeq.ControlPointSequence.(FieldSeqNames{i}{j});
+    
+    for j = 1:length(currControlPointSeqNames)
+       counter = counter + 1;
+       currControlPointElement = currBeamSeq.ControlPointSequence.(currControlPointSeqNames{j});      
         
-        % get the leaf position for every device
-        Collimation.Fields(counter).LeafPos{length(DeviceSeqNames),1} = [];
-        for k = 1:length(DeviceSeqNames)
-            currLeafPos = currFieldSeq.BeamLimitingDevicePositionSequence.(DeviceSeqNames{k}).LeafJawPositions;
-            
-            Collimation.Fields(counter).LeafPos{k} = NaN*ones(Collimation.Devices(k).NumOfLeafs,2);
-            Collimation.Fields(counter).LeafPos{k}(:,1) = currLeafPos(1:Collimation.Devices(k).NumOfLeafs);
-            Collimation.Fields(counter).LeafPos{k}(:,2) = currLeafPos(Collimation.Devices(k).NumOfLeafs+1:end); 
-        end
+       if isfield(currControlPointElement, 'BeamLimitingDevicePositionSequence')
+           % get the leaf position for every device
+           collimation.Fields(counter).LeafPos{length(currDeviceSeqNames),1} = [];
+           for k = 1:length(currDeviceSeqNames)
+               % beam limiting device position sequence has to be defined on
+               % the first control point and has to be defined on following
+               % points only if it changes
+               currLeafPos = currControlPointElement.BeamLimitingDevicePositionSequence.(currDeviceSeqNames{k}).LeafJawPositions;          
+
+               if (length(currLeafPos) ~= 2 * device(k).NumOfLeafs)
+                   warning(['Number of leafs/jaws does not match given number of leaf/jaw positions in control point sequence ' ...
+                            currControlPointSeqNames{j} ' on beam sequence ' BeamSeqNames{i} ' for device ' ...
+                            device(k).DeviceType '. No field shape import performed!']);
+                   return;
+               end
+               collimation.Fields(counter).LeafPos{k} = NaN*ones(device(k).NumOfLeafs,2);
+               collimation.Fields(counter).LeafPos{k}(:,1) = currLeafPos(1:device(k).NumOfLeafs);
+               collimation.Fields(counter).LeafPos{k}(:,2) = currLeafPos(device(k).NumOfLeafs+1:end); 
+           end
+       else
+           collimation.Fields(counter) = collimation.Fields(counter - 1);
+       end
+       
+       % get field meta information
+       newCumWeight = currBeamSeq.ControlPointSequence.(currControlPointSeqNames{j}).CumulativeMetersetWeight;
+       collimation.Fields(counter).Weight = newCumWeight - cumWeight;
+       cumWeight = newCumWeight;
+       collimation.Fields(counter).FinalCumWeight = currBeamSeq.FinalCumulativeMetersetWeight;
+       collimation.Fields(counter).SAD = currBeamSeq.SourceAxisDistance;
         
-        % get field meta information
-        newCumWeight = currBeamSeq.ControlPointSequence.(FieldSeqNames{i}{j}).CumulativeMetersetWeight;
-        Collimation.Fields(counter).Weight = newCumWeight - cumWeight;
-        cumWeight = newCumWeight;
-        Collimation.Fields(counter).FinalCumWeight = currBeamSeq.FinalCumulativeMetersetWeight;
-        Collimation.Fields(counter).SAD = currBeamSeq.SourceAxisDistance;
-        
-        % other meta information is only included in all control point
-        % sequences if it changes during treatment, otherwise use FieldMeta
-        for k = 1:length(meta)
-            if isfield(currFieldSeq,meta{k,1})
-                Collimation.Fields(counter).(meta{k,2}) = currFieldSeq.(meta{k,1});
-            else
-                Collimation.Fields(counter).(meta{k,2}) = FieldMeta.(meta{k,2});
-            end
-        end
-        
-        
-        Collimation.FieldOfBeam(counter) = i;
+       % other meta information is only included in all control point
+       % sequences if it changes during treatment, otherwise use FieldMeta
+       for k = 1:length(meta)
+           if isfield(currControlPointElement,meta{k,1})
+               collimation.Fields(counter).(meta{k,2}) = currControlPointElement.(meta{k,1});
+           else
+               collimation.Fields(counter).(meta{k,2}) = FieldMeta.(meta{k,2});
+           end
+       end
+       % save information which control point sequence belongs to which beam sequence       
+       collimation.FieldOfBeam(counter).BeamIndex = i;
     end
 end
+collimation.numOfFields = counter;
 
 % use same dimensions for field shapes as for the kernel convolution in
 % photon dose calculation
@@ -119,26 +130,32 @@ convResolution = .5; % [mm]
 
 % calculate field shapes from leaf positions
 counter = 0;
-for i = 1:length(Collimation.Fields)
+for i = 1:length(collimation.Fields)
     counter = counter + 1;
     shape = ones(2*convLimits/convResolution); 
-    for j = 1:length(DeviceSeqNames)
-        % only ASYMX/Y and MLCX/Y are yet supported due to limited example dicoms
-        if strncmpi(Collimation.Devices(j).DeviceType,'ASYM',4)
+    beamIndex = collimation.FieldOfBeam(i).BeamIndex;
+    for j = 1:length(currDeviceSeqNames)
+        % check for ASYM and SYM jaws == type 1
+        if strncmpi(collimation.Devices{beamIndex}(j).DeviceType,'ASYM',4)
             type = 1;
-        elseif strncmpi(Collimation.Devices(j).DeviceType,'MLC',3)
+        elseif (strcmpi(collimation.Devices{beamIndex}(j).DeviceType,'X') || ...
+                strcmpi(collimation.Devices{beamIndex}(j).DeviceType,'Y'))
+            type = 1;
+        % MLC == type 2
+        elseif strncmpi(collimation.Devices{beamIndex}(j).DeviceType,'MLC',3)
             type = 2;
         else
-            errordlg('Device type not yet supported, not all field shapes could be completely imported!');
-            continue;
+            warning(['Device type ' collimation.Devices{beamIndex}(j).DeviceType ...
+                    ' not supported. Field shapes could not be imported!']);
+            return;
         end
-        for k = 1:Collimation.Devices(j).NumOfLeafs
+        for k = 1:collimation.Devices{beamIndex}(j).NumOfLeafs
             % determine corner points of the open area
-            p1 = round((Collimation.Fields(i).LeafPos{j}(k,1)+convLimits)/convResolution+1); 
-            p2 = round((Collimation.Fields(i).LeafPos{j}(k,2)+convLimits)/convResolution+1);
+            p1 = round((collimation.Fields(i).LeafPos{j}(k,1)+convLimits)/convResolution+1); 
+            p2 = round((collimation.Fields(i).LeafPos{j}(k,2)+convLimits)/convResolution+1);
             if type == 2
-                p3 = round((Collimation.Devices(j).Limits(k)+convLimits)/convResolution+1);
-                p4 = round((Collimation.Devices(j).Limits(k+1)+convLimits)/convResolution+1);
+                p3 = round((collimation.Devices{beamIndex}(j).Limits(k)+convLimits)/convResolution+1);
+                p4 = round((collimation.Devices{beamIndex}(j).Limits(k+1)+convLimits)/convResolution+1);
             else % for one dimensional collimation (ASMX/Y) other direction is fully open
                 p3 = 1;
                 p4 = 2*convLimits/convResolution;
@@ -151,25 +168,27 @@ for i = 1:length(Collimation.Fields)
                (p3 > 0) && (p3 <= 2*convLimits/convResolution) && ...
                (p4 > 0) && (p4 <= 2*convLimits/convResolution+1)
                 try
-                    if strcmpi(Collimation.Devices(j).Direction, 'X')
+                    if strcmpi(collimation.Devices{beamIndex}(j).Direction, 'X')
                         shape(p3:(p4-1),1:(p1-1)) = 0;
                         shape(p3:(p4-1),p2:end) = 0;
-                    elseif strcmpi(Collimation.Devices(j).Direction, 'Y')
+                    elseif strcmpi(collimation.Devices{beamIndex}(j).Direction, 'Y')
                         shape(1:(p1-1),p3:(p4-1)) = 0;
                         shape(p2:end,p3:(p4-1)) = 0;
                     else
-                        errordlg('Wrong collimation direction given! Not all fields could be imported.');
-                        continue;
+                        warning(['Wrong collimation direction ' collimation.Devices{beamIndex}(j).Direction ...
+                                 ' given for device ' collimation.Devices{beamIndex}(j).DeviceType ...
+                                 '. Fields could not be imported.']);
+                        return;
                     end
                 catch
-                    warning('Error in setting field shapes. Only open field sizes up to 200x200 mm are supported')
-                    continue;
+                    warning('Error in setting field shapes. Field shapes could not be imported.')
+                    return;
                 end
             end
         end
     end
-    Collimation.Fields(i).Shape = shape;
+    collimation.Fields(i).Shape = shape;
 end
 
-
+Collimation = collimation;
 end

--- a/dicomImport/matRad_importFieldShapes.m
+++ b/dicomImport/matRad_importFieldShapes.m
@@ -102,9 +102,15 @@ for i = 1:length(BeamSeqNames)
        end
        
        % get field meta information
-       newCumWeight = currBeamSeq.ControlPointSequence.(currControlPointSeqNames{j}).CumulativeMetersetWeight;
-       collimation.Fields(counter).Weight = newCumWeight - cumWeight;
-       cumWeight = newCumWeight;
+       if isfield(currControlPointElement, 'CumulativeMetersetWeight')      
+           newCumWeight = currControlPointElement.CumulativeMetersetWeight;
+           collimation.Fields(counter).Weight = newCumWeight - cumWeight;
+           cumWeight = newCumWeight;
+       else
+           warning(['No CumulativeMetersetWeight found in control point sequence ' currControlPointSeqNames{j} ...
+                    ' on beam ' BeamSeqNames{i} '. No field shape import performed!']);
+           return;
+       end
        collimation.Fields(counter).FinalCumWeight = currBeamSeq.FinalCumulativeMetersetWeight;
        collimation.Fields(counter).SAD = currBeamSeq.SourceAxisDistance;
         


### PR DESCRIPTION
* fix a bug where the import would crash for a control point sequence with constant beam limiting device position sequences which are only specified in the first element
* improve exception handling during the field import
* minor changes to variable names to better reflect the DICOM structure