### PR TITLE
Bugfix in DijSampling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.fig
+*.mat
+Sequencing Test/DAO_Apertures_3.gif

--- a/matRad_DijSampling.m
+++ b/matRad_DijSampling.m
@@ -80,47 +80,55 @@ end
 
 bixelDoseCore       = bixelDose(ixCore);                         % save dose values that are not affected by sampling
 
-logIxTail           = ~ixCore;                                   % get voxels indices beyond r0
-linIxTail           = find(logIxTail);                           % convert logical index to linear index
-numTail             = numel(linIxTail);
-bixelDoseTail       = bixelDose(linIxTail);                      % dose values that are going to be reduced by sampling
-ixTail              = ix(linIxTail);                             % indices that are going to be reduced by sampling
-
-%% sample for each radiological depth the lateral halo dose  
-radDepthTail        = (radDepthV(linIxTail));                    % get radiological depth in the tail
-
-% cluster radiological dephts to reduce computations
-B_r                 = int32(ceil(radDepthTail));                 % cluster radiological depths;
-maxRadDepth         = double(max(B_r));
-C                   = int32(linspace(0,maxRadDepth,round(maxRadDepth)/deltaRadDepth));     % coarse clustering of rad depths    
-
-ixNew               = zeros(numTail,1);                          % inizialize new index vector
-bixelDoseNew        = zeros(numTail,1);                          % inizialize new dose vector
-linIx               = int32(1:1:numTail)';
-IxCnt               = 1;
-
-%% loop over clustered radiological depths
-for i = 1:numel(C)-1
-    ixTmp              = linIx(B_r >= C(i) & B_r < C(i+1));      % extracting sub indices
-    if isempty(ixTmp)
-        continue
-    end 
-    subDose            = bixelDoseTail(ixTmp);                   % get tail dose in current cluster
-    subIx              = ixTail(ixTmp);                          % get indices in current cluster
-    thresholdDose      = max(subDose); 
-    r                  = rand(numel(subDose),1);                 % get random samples
-    ixSamp             = r<=(subDose/thresholdDose);
-    NumSamples         = sum(ixSamp);
-
-    ixNew(IxCnt:IxCnt+NumSamples-1,1)        = subIx(ixSamp);    % save new indices
-    bixelDoseNew(IxCnt:IxCnt+NumSamples-1,1) = thresholdDose;    % set the dose
-    IxCnt = IxCnt + NumSamples;    
+if all(ixCore)
+    %exit function with core dose only
+    ixNew = ix(ixCore);
+    bixelDoseNew = bixelDoseCore;
+else
+    logIxTail           = ~ixCore;                                   % get voxels indices beyond r0
+    linIxTail           = find(logIxTail);                           % convert logical index to linear index
+    numTail             = numel(linIxTail);
+    bixelDoseTail       = bixelDose(linIxTail);                      % dose values that are going to be reduced by sampling
+    ixTail              = ix(linIxTail);                             % indices that are going to be reduced by sampling
+    
+    %% sample for each radiological depth the lateral halo dose
+    radDepthTail        = (radDepthV(linIxTail));                    % get radiological depth in the tail
+    
+    % cluster radiological dephts to reduce computations
+    B_r                 = int32(ceil(radDepthTail));                 % cluster radiological depths;
+    maxRadDepth         = double(max(B_r));
+    C                   = int32(linspace(0,maxRadDepth,round(maxRadDepth)/deltaRadDepth));     % coarse clustering of rad depths
+    
+    ixNew               = zeros(numTail,1);                          % inizialize new index vector
+    bixelDoseNew        = zeros(numTail,1);                          % inizialize new dose vector
+    linIx               = int32(1:1:numTail)';
+    IxCnt               = 1;
+    
+    %% loop over clustered radiological depths
+    for i = 1:numel(C)-1
+        ixTmp              = linIx(B_r >= C(i) & B_r < C(i+1));      % extracting sub indices
+        if isempty(ixTmp)
+            continue
+        end
+        subDose            = bixelDoseTail(ixTmp);                   % get tail dose in current cluster
+        subIx              = ixTail(ixTmp);                          % get indices in current cluster
+        thresholdDose      = max(subDose);
+        r                  = rand(numel(subDose),1);                 % get random samples
+        ixSamp             = r<=(subDose/thresholdDose);
+        NumSamples         = sum(ixSamp);
+        
+        ixNew(IxCnt:IxCnt+NumSamples-1,1)        = subIx(ixSamp);    % save new indices
+        bixelDoseNew(IxCnt:IxCnt+NumSamples-1,1) = thresholdDose;    % set the dose
+        IxCnt = IxCnt + NumSamples;
+    end
+    
+    
+    % cut new vectors and add inner core values
+    ixNew        = [ix(ixCore);    ixNew(1:IxCnt-1)];
+    bixelDoseNew = [bixelDoseCore; bixelDoseNew(1:IxCnt-1)];
 end
 
 
-% cut new vectors and add inner core values  
-ixNew        = [ix(ixCore);    ixNew(1:IxCnt-1)];
-bixelDoseNew = [bixelDoseCore; bixelDoseNew(1:IxCnt-1)];
 
 end
 

--- a/matRad_DijSampling.m
+++ b/matRad_DijSampling.m
@@ -81,6 +81,7 @@ end
 bixelDoseCore       = bixelDose(ixCore);                         % save dose values that are not affected by sampling
 
 if all(ixCore)
+    %% all bixels are in the core
     %exit function with core dose only
     ixNew = ix(ixCore);
     bixelDoseNew = bixelDoseCore;


### PR DESCRIPTION
Old behaviour: if all bixels were in the core, the outer-core sampling
would still be attempted, resulting in an error message when attempting
to do the linspace (since the radDepthTail would be empty).

New behaviour: if all bixels are in the core, exit function with core
dose only.  Otherwise, proceed to rest of function.