### PR TITLE
Dev rotation outsourcing

### DIFF
--- a/dicomImport/matRad_importDicomSteeringParticles.m
+++ b/dicomImport/matRad_importDicomSteeringParticles.m
@@ -195,7 +195,7 @@ for i = 1:length(BeamSeqNames)
     
     % coordinate transformation with rotation matrix.
     % use transpose matrix because we are working with row vectors
-    rotMat_vectors_T = transpose(matRad_getRotationMatrix(pln,i));
+    rotMat_vectors_T = transpose(matRad_getRotationMatrix(pln.gantryAngles(i),pln.couchAngles(i)));
 
     % Rotated Source point (1st gantry, 2nd couch)
     stf(i).sourcePoint = stf(i).sourcePoint_bev*rotMat_vectors_T;

--- a/dicomImport/matRad_importDicomSteeringPhotons.m
+++ b/dicomImport/matRad_importDicomSteeringPhotons.m
@@ -63,28 +63,21 @@ for i = 1:size(UniqueComb,1)
     stf(i).SAD               = Fields(ia(i)).SAD;
     stf(i).sourcePoint_bev   = [0 -stf(i).SAD 0];
     
-    % compute coordinates in lps coordinate system, i.e. rotate beam
-    % geometry around fixed patient; use transpose matrices because we are
-    % working with row vectors
-    % Rotation around Z axis (gantry)
-    rotMx_XY_T = [ cosd(stf(i).gantryAngle) sind(stf(i).gantryAngle) 0;
-                  -sind(stf(i).gantryAngle) cosd(stf(i).gantryAngle) 0;
-                                          0                        0 1];
-    % Rotation around Y axis (couch)
-    rotMx_XZ_T = [cosd(stf(i).couchAngle) 0 -sind(stf(i).couchAngle);
-                                        0 1                        0;
-                  sind(stf(i).couchAngle) 0  cosd(stf(i).couchAngle)];
+    % coordinate transformation with rotation matrix.
+    % use transpose matrix because we are working with row vectors
+    rotMat_vectors_T = transpose(matRad_getRotationMatrix(stf(i).gantryAngle,stf(i).couchAngle));
+
 
     % Rotated Source point (1st gantry, 2nd couch)
-    stf(i).sourcePoint = stf(i).sourcePoint_bev*rotMx_XY_T*rotMx_XZ_T;
+    stf(i).sourcePoint = stf(i).sourcePoint_bev*rotMat_vectors_T;
     
     % only one ray in center position
     stf(i).ray.rayPos_bev = [0 0 0];
-    stf(i).ray.rayPos     = stf(i).ray.rayPos_bev*rotMx_XY_T*rotMx_XZ_T;
+    stf(i).ray.rayPos     = stf(i).ray.rayPos_bev*rotMat_vectors_T;
 
     % target point is for ray in center position at
     stf(i).ray.targetPoint_bev = [0 stf(i).SAD 0];
-    stf(i).ray.targetPoint     = stf(i).ray.targetPoint_bev*rotMx_XY_T*rotMx_XZ_T;
+    stf(i).ray.targetPoint     = stf(i).ray.targetPoint_bev*rotMat_vectors_T;
     
     % set weight for output field
     stf(i).ray.weight = Fields(ia(i)).FinalCumWeight;

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -1083,14 +1083,9 @@ if get(handles.popupTypeOfPlot,'Value') == 2 && exist('Result','var')
     ylabel('{\color{black}dose [Gy]}')
     cColor={'black','green','magenta','cyan','yellow','red','blue'};
     
-    % Rotation around Z axis (table movement)
-    inv_rotMx_XY_T = [ cosd(pln.gantryAngles(handles.SelectedBeam)) sind(pln.gantryAngles(handles.SelectedBeam)) 0;
-                      -sind(pln.gantryAngles(handles.SelectedBeam)) cosd(pln.gantryAngles(handles.SelectedBeam)) 0;
-                                                                  0 0 1];
-    % Rotation around Y axis (Couch movement)
-    inv_rotMx_XZ_T = [cosd(pln.couchAngles(handles.SelectedBeam)) 0 -sind(pln.couchAngles(handles.SelectedBeam));
-                                                                0 1 0;
-                      sind(pln.couchAngles(handles.SelectedBeam)) 0 cosd(pln.couchAngles(handles.SelectedBeam))];
+    % Get Rotation. passive rotation & row vector multiplication
+    %  requires double matrix transpose and thus does not affect the matrix                  
+    rotMat_system_T = matRad_getRotationMatrix(pln,handles.SelectedBeam);
     
     if strcmp(handles.ProfileType,'longitudinal')
         sourcePointBEV = [handles.profileOffset -SAD   0];
@@ -1100,8 +1095,8 @@ if get(handles.popupTypeOfPlot,'Value') == 2 && exist('Result','var')
         targetPointBEV = [ SAD handles.profileOffset   0];
     end
     
-    rotSourcePointBEV = sourcePointBEV * inv_rotMx_XZ_T * inv_rotMx_XY_T;
-    rotTargetPointBEV = targetPointBEV * inv_rotMx_XZ_T * inv_rotMx_XY_T;
+    rotSourcePointBEV = sourcePointBEV * rotMat_system_T;
+    rotTargetPointBEV = targetPointBEV * rotMat_system_T;
     
     % perform raytracing on the central axis of the selected beam
     [~,l,rho,~,ix] = matRad_siddonRayTracer(pln.isoCenter,ct.resolution,rotSourcePointBEV,rotTargetPointBEV,{ct.cube{1}});

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -1083,9 +1083,9 @@ if get(handles.popupTypeOfPlot,'Value') == 2 && exist('Result','var')
     ylabel('{\color{black}dose [Gy]}')
     cColor={'black','green','magenta','cyan','yellow','red','blue'};
     
-    % Get Rotation. passive rotation & row vector multiplication
-    %  requires double matrix transpose and thus does not affect the matrix                  
-    rotMat_system_T = matRad_getRotationMatrix(pln.gantryAngles(handles.SelectedBeam),pln.couchAngles(handles.SelectedBeam));
+    % Rotate the system into the beam. 
+    % passive rotation & row vector multiplication & inverted rotation requires triple matrix transpose                  
+    rotMat_system_T = transpose(matRad_getRotationMatrix(pln.gantryAngles(handles.SelectedBeam),pln.couchAngles(handles.SelectedBeam)));
     
     if strcmp(handles.ProfileType,'longitudinal')
         sourcePointBEV = [handles.profileOffset -SAD   0];

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -1085,7 +1085,7 @@ if get(handles.popupTypeOfPlot,'Value') == 2 && exist('Result','var')
     
     % Get Rotation. passive rotation & row vector multiplication
     %  requires double matrix transpose and thus does not affect the matrix                  
-    rotMat_system_T = matRad_getRotationMatrix(pln,handles.SelectedBeam);
+    rotMat_system_T = matRad_getRotationMatrix(pln.gantryAngles(handles.SelectedBeam),pln.couchAngles(handles.SelectedBeam));
     
     if strcmp(handles.ProfileType,'longitudinal')
         sourcePointBEV = [handles.profileOffset -SAD   0];

--- a/matRad_calcParticleDose.m
+++ b/matRad_calcParticleDose.m
@@ -185,7 +185,7 @@ for i = 1:dij.numOfBeams % loop over all beams
     % transformation of the coordinate system need double transpose
 
     % rotation around Z axis (gantry)
-    rotMat_system_T = matRad_getRotationMatrix(pln,i);
+    rotMat_system_T = matRad_getRotationMatrix(pln.gantryAngles(i),pln.couchAngles(i));
 
     % Rotate coordinates (1st couch around Y axis, 2nd gantry movement)
     rot_coordsV = coordsV*rotMat_system_T;

--- a/matRad_calcParticleDose.m
+++ b/matRad_calcParticleDose.m
@@ -180,21 +180,15 @@ for i = 1:dij.numOfBeams % loop over all beams
     zCoordsV = zCoordsV_vox(:)*ct.resolution.z-stf(i).isoCenter(3);
     coordsV  = [xCoordsV yCoordsV zCoordsV];
 
-    % Set gantry and couch rotation matrices according to IEC 61217
-    % Use transpose matrices because we are working with row vectros
+    % Get Rotation Matrix
+    % Do not transpose matrix since we usage of row vectors &
+    % transformation of the coordinate system need double transpose
 
     % rotation around Z axis (gantry)
-    inv_rotMx_XY_T = [ cosd(-pln.gantryAngles(i)) sind(-pln.gantryAngles(i)) 0;
-                      -sind(-pln.gantryAngles(i)) cosd(-pln.gantryAngles(i)) 0;
-                                                0                          0 1];
-
-    % rotation around Y axis (couch)
-    inv_rotMx_XZ_T = [cosd(-pln.couchAngles(i)) 0 -sind(-pln.couchAngles(i));
-                                              0 1                         0;
-                      sind(-pln.couchAngles(i)) 0  cosd(-pln.couchAngles(i))];
+    rotMat_system_T = matRad_getRotationMatrix(pln,i);
 
     % Rotate coordinates (1st couch around Y axis, 2nd gantry movement)
-    rot_coordsV = coordsV*inv_rotMx_XZ_T*inv_rotMx_XY_T;
+    rot_coordsV = coordsV*rotMat_system_T;
 
     rot_coordsV(:,1) = rot_coordsV(:,1)-stf(i).sourcePoint_bev(1);
     rot_coordsV(:,2) = rot_coordsV(:,2)-stf(i).sourcePoint_bev(2);

--- a/matRad_calcPhotonDose.m
+++ b/matRad_calcPhotonDose.m
@@ -151,21 +151,14 @@ for i = 1:dij.numOfBeams; % loop over all beams
     zCoordsV = zCoordsV_vox(:)*ct.resolution.z-stf(i).isoCenter(3);
     coordsV  = [xCoordsV yCoordsV zCoordsV];
 
-    % Set gantry and couch rotation matrices according to IEC 61217
-    % Use transpose matrices because we are working with row vectros
+    % Get Rotation Matrix
+    % Do not transpose matrix since we usage of row vectors &
+    % transformation of the coordinate system need double transpose
 
-    % rotation around Z axis (gantry)
-    inv_rotMx_XY_T = [ cosd(-pln.gantryAngles(i)) sind(-pln.gantryAngles(i)) 0;
-                      -sind(-pln.gantryAngles(i)) cosd(-pln.gantryAngles(i)) 0;
-                                                0                          0 1];
-
-    % rotation around Y axis (couch)
-    inv_rotMx_XZ_T = [cosd(-pln.couchAngles(i)) 0 -sind(-pln.couchAngles(i));
-                                              0 1                         0;
-                      sind(-pln.couchAngles(i)) 0  cosd(-pln.couchAngles(i))];
+    rotMat_system_T = matRad_getRotationMatrix(pln,i);
 
     % Rotate coordinates (1st couch around Y axis, 2nd gantry movement)
-    rot_coordsV = coordsV*inv_rotMx_XZ_T*inv_rotMx_XY_T;
+    rot_coordsV = coordsV*rotMat_system_T;
 
     rot_coordsV(:,1) = rot_coordsV(:,1)-stf(i).sourcePoint_bev(1);
     rot_coordsV(:,2) = rot_coordsV(:,2)-stf(i).sourcePoint_bev(2);

--- a/matRad_calcPhotonDose.m
+++ b/matRad_calcPhotonDose.m
@@ -155,7 +155,7 @@ for i = 1:dij.numOfBeams; % loop over all beams
     % Do not transpose matrix since we usage of row vectors &
     % transformation of the coordinate system need double transpose
 
-    rotMat_system_T = matRad_getRotationMatrix(pln,i);
+    rotMat_system_T = matRad_getRotationMatrix(pln.gantryAngles(i),pln.couchAngles(i));
 
     % Rotate coordinates (1st couch around Y axis, 2nd gantry movement)
     rot_coordsV = coordsV*rotMat_system_T;

--- a/matRad_generateStf.m
+++ b/matRad_generateStf.m
@@ -121,7 +121,7 @@ for i = 1:length(pln.gantryAngles)
     % rotation with row vector coordinates, which would introduce two 
     % inversions / transpositions of the matrix, thus no changes to the
     % rotation matrix are necessary
-    rotMat_system_T = matRad_getRotationMatrix(pln,i);
+    rotMat_system_T = matRad_getRotationMatrix(pln.gantryAngles(i),pln.couchAngles(i));
     
     rot_coords = [coordsX coordsY coordsZ]*rotMat_system_T;
     
@@ -187,7 +187,7 @@ for i = 1:length(pln.gantryAngles)
     
     % get (active) rotation matrix 
     % transpose matrix because we are working with row vectors
-    rotMat_vectors_T = transpose(matRad_getRotationMatrix(pln,i));
+    rotMat_vectors_T = transpose(matRad_getRotationMatrix(pln.gantryAngles(i),pln.couchAngles(i)));
     
     
     stf(i).sourcePoint = stf(i).sourcePoint_bev*rotMat_vectors_T;

--- a/matRad_generateStf.m
+++ b/matRad_generateStf.m
@@ -117,25 +117,13 @@ for i = 1:length(pln.gantryAngles)
     stf(i).SAD           = SAD;
     stf(i).isoCenter     = pln.isoCenter;
     
-    % gantry and couch roation matrices according to IEC 61217 standard
-    % instead of moving the beam around the patient, we perform an inverse
-    % rotation of the patient, i.e. we consider a beam's eye view
-    % coordinate system; use transpose matrices because we are working with
-    % row vectors
+    % Get the (active) rotation matrix. We perform a passive/system 
+    % rotation with row vector coordinates, which would introduce two 
+    % inversions / transpositions of the matrix, thus no changes to the
+    % rotation matrix are necessary
+    rotMat_system_T = matRad_getRotationMatrix(pln,i);
     
-    % Rotation around Z axis (gantry)
-    inv_rotMx_XY_T = [ cosd(-pln.gantryAngles(i)) sind(-pln.gantryAngles(i)) 0;
-                      -sind(-pln.gantryAngles(i)) cosd(-pln.gantryAngles(i)) 0;
-                                                0                          0 1];
-    
-    % Rotation around Y axis (Couch movement)
-    inv_rotMx_XZ_T = [cosd(-pln.couchAngles(i)) 0 -sind(-pln.couchAngles(i));
-                                              0 1                          0;
-                      sind(-pln.couchAngles(i)) 0  cosd(-pln.couchAngles(i))];
-    
-    % rotate target coordinates (1st couch around Y axis, 2nd gantry around
-    % z axis); matrix multiplication not cummutative
-    rot_coords = [coordsX coordsY coordsZ]*inv_rotMx_XZ_T*inv_rotMx_XY_T;
+    rot_coords = [coordsX coordsY coordsZ]*rotMat_system_T;
     
     % project x and z coordinates to isocenter
     coordsAtIsoCenterPlane(:,1) = (rot_coords(:,1)*SAD)./(SAD + rot_coords(:,2));
@@ -197,33 +185,23 @@ for i = 1:length(pln.gantryAngles)
     % source position in bev
     stf(i).sourcePoint_bev = [0 -SAD 0];
     
-    % compute coordinates in lps coordinate system, i.e. rotate beam
-    % geometry around fixed patient; use transpose matrices because we are
-    % working with row vectors
+    % get (active) rotation matrix 
+    % transpose matrix because we are working with row vectors
+    rotMat_vectors_T = transpose(matRad_getRotationMatrix(pln,i));
     
-    % Rotation around Z axis (gantry)
-    rotMx_XY_T = [ cosd(pln.gantryAngles(i)) sind(pln.gantryAngles(i)) 0;
-                  -sind(pln.gantryAngles(i)) cosd(pln.gantryAngles(i)) 0;
-                                           0                         0 1];
     
-    % Rotation around Y axis (couch)
-    rotMx_XZ_T = [cosd(pln.couchAngles(i)) 0 -sind(pln.couchAngles(i));
-                                         0 1                        0;
-                  sind(pln.couchAngles(i)) 0  cosd(pln.couchAngles(i))];
-    
-    % Rotated Source point (1st gantry, 2nd couch)
-    stf(i).sourcePoint = stf(i).sourcePoint_bev*rotMx_XY_T*rotMx_XZ_T;
+    stf(i).sourcePoint = stf(i).sourcePoint_bev*rotMat_vectors_T;
     
     % Save ray and target position in lps system.
     for j = 1:stf(i).numOfRays
-        stf(i).ray(j).rayPos      = stf(i).ray(j).rayPos_bev*rotMx_XY_T*rotMx_XZ_T;
-        stf(i).ray(j).targetPoint = stf(i).ray(j).targetPoint_bev*rotMx_XY_T*rotMx_XZ_T;
+        stf(i).ray(j).rayPos      = stf(i).ray(j).rayPos_bev*rotMat_vectors_T;
+        stf(i).ray(j).targetPoint = stf(i).ray(j).targetPoint_bev*rotMat_vectors_T;
         if strcmp(pln.radiationMode,'photons') 
             stf(i).ray(j).rayCorners_SCD = (repmat([0, machine.meta.SCD - SAD, 0],4,1)+ (machine.meta.SCD/SAD) * ...
                                                              [rayPos(j,:) + [+stf(i).bixelWidth/2,0,+stf(i).bixelWidth/2];...
                                                               rayPos(j,:) + [-stf(i).bixelWidth/2,0,+stf(i).bixelWidth/2];...
                                                               rayPos(j,:) + [-stf(i).bixelWidth/2,0,-stf(i).bixelWidth/2];...
-                                                              rayPos(j,:) + [+stf(i).bixelWidth/2,0,-stf(i).bixelWidth/2]])*rotMx_XY_T*rotMx_XZ_T;
+                                                              rayPos(j,:) + [+stf(i).bixelWidth/2,0,-stf(i).bixelWidth/2]])*rotMat_vectors_T;
         end
     end
     
@@ -364,7 +342,7 @@ for i = 1:length(pln.gantryAngles)
             v(:,3) = v(:,3)*ct.resolution.z;
             
             % rotate surface
-            rotated_surface = v*inv_rotMx_XZ_T*inv_rotMx_XY_T;
+            rotated_surface = v*rotMat_system_T;
             
             % surface rendering
             surface = patch('Faces',f,'Vertices',rotated_surface);
@@ -421,7 +399,7 @@ for i = 1:length(pln.gantryAngles)
         hold on;
         
         % Rotated projection matrix at isocenter
-        isocenter_plane_coor = rayPos*rotMx_XY_T*rotMx_XZ_T;
+        isocenter_plane_coor = rayPos*rotMat_vectors_T;
         
         % Plot isocenter plane
         plot3(isocenter_plane_coor(:,1),isocenter_plane_coor(:,2),isocenter_plane_coor(:,3),'y.');
@@ -429,10 +407,10 @@ for i = 1:length(pln.gantryAngles)
         % Plot rotated bixels border.
         for j = 1:stf(i).numOfRays
             % Generate rotated projection target points.
-            targetPoint_vox_1_rotated = [stf(i).ray(j).targetPoint_bev(:,1) + pln.bixelWidth,stf(i).ray(j).targetPoint_bev(:,2),stf(i).ray(j).targetPoint_bev(:,3) + pln.bixelWidth]*rotMx_XY_T*rotMx_XZ_T;
-            targetPoint_vox_2_rotated = [stf(i).ray(j).targetPoint_bev(:,1) + pln.bixelWidth,stf(i).ray(j).targetPoint_bev(:,2),stf(i).ray(j).targetPoint_bev(:,3) - pln.bixelWidth]*rotMx_XY_T*rotMx_XZ_T;
-            targetPoint_vox_3_rotated = [stf(i).ray(j).targetPoint_bev(:,1) - pln.bixelWidth,stf(i).ray(j).targetPoint_bev(:,2),stf(i).ray(j).targetPoint_bev(:,3) - pln.bixelWidth]*rotMx_XY_T*rotMx_XZ_T;
-            targetPoint_vox_4_rotated = [stf(i).ray(j).targetPoint_bev(:,1) - pln.bixelWidth,stf(i).ray(j).targetPoint_bev(:,2),stf(i).ray(j).targetPoint_bev(:,3) + pln.bixelWidth]*rotMx_XY_T*rotMx_XZ_T;
+            targetPoint_vox_1_rotated = [stf(i).ray(j).targetPoint_bev(:,1) + pln.bixelWidth,stf(i).ray(j).targetPoint_bev(:,2),stf(i).ray(j).targetPoint_bev(:,3) + pln.bixelWidth]*rotMat_vectors_T;
+            targetPoint_vox_2_rotated = [stf(i).ray(j).targetPoint_bev(:,1) + pln.bixelWidth,stf(i).ray(j).targetPoint_bev(:,2),stf(i).ray(j).targetPoint_bev(:,3) - pln.bixelWidth]*rotMat_vectors_T;
+            targetPoint_vox_3_rotated = [stf(i).ray(j).targetPoint_bev(:,1) - pln.bixelWidth,stf(i).ray(j).targetPoint_bev(:,2),stf(i).ray(j).targetPoint_bev(:,3) - pln.bixelWidth]*rotMat_vectors_T;
+            targetPoint_vox_4_rotated = [stf(i).ray(j).targetPoint_bev(:,1) - pln.bixelWidth,stf(i).ray(j).targetPoint_bev(:,2),stf(i).ray(j).targetPoint_bev(:,3) + pln.bixelWidth]*rotMat_vectors_T;
             
             % Plot rotated target points.
             plot3([stf(i).sourcePoint(1) targetPoint_vox_1_rotated(:,1)],[stf(i).sourcePoint(2) targetPoint_vox_1_rotated(:,2)],[stf(i).sourcePoint(3) targetPoint_vox_1_rotated(:,3)],'g')

--- a/matRad_getRotationMatrix.m
+++ b/matRad_getRotationMatrix.m
@@ -1,0 +1,107 @@
+function rotMat = matRad_getRotationMatrix(arg1,arg2,type,system)
+% matRad function to return the rotation / transformation matrix for various
+% scenarios according to IEC 61217.
+% 
+% call
+%  rotMat = matRad_getRotationMatrix(gantryAngle,couchAngle,type,system)
+%  rotMat = matRad_getRotationMatrix(pln,fieldIx,type,system)
+%
+% input
+%   gantryAngle:    beam/gantry angle
+%   couchAngle:     couch angle 
+%   or  
+%   pln:            matRad plan meta information struct
+%   fieldIx:        index of the field / beam that is requested
+%   
+%   type:       optional parameter. Can be 'full' (both rotations as
+%                   matrix, default) or 'gantry' / 'couch' for the 
+%                   individual matrices
+%   system:         optional coordinate system the transformation matrix is
+%                   requested for. So far, only the default option 'LPS' is
+%                   supported (right handed system).
+%
+% output
+%   rotMat:         3x3 matrix that performs a rotation around the patient
+%                   via rotMat * x
+%
+% References
+%   -
+%
+% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% Copyright 2015 the matRad development team. 
+% 
+% This file is part of the matRad project. It is subject to the license 
+% terms in the LICENSE file found in the top-level directory of this 
+% distribution and at https://github.com/e0404/matRad/LICENSES.txt. No part 
+% of the matRad project, including this file, may be copied, modified, 
+% propagated, or distributed except according to the terms contained in the 
+% LICENSE file.
+%
+% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% Parse arguments
+%We need at least two and max 6 input arguments
+narginchk(2,4);
+%check if a pln and index have been given
+if isstruct(arg1)
+    pln = arg1;
+    fieldIx = arg2;
+    gantryAngle = pln.gantryAngles(fieldIx);
+    couchAngle = pln.couchAngles(fieldIx);
+else
+    gantryAngle = arg1;
+    couchAngle = arg2;
+end 
+% Coordinate System (only LPS so far)
+if nargin < 4
+    system = 'LPS';
+end
+%Gantry, Couch, or full transformation?
+if nargin < 3
+    type = 'full';
+end
+
+%% Set Up requested Rotation Matrix
+switch system
+    case 'LPS'
+        %The LPS system is right-handed, gantry rotates counter-clockwise 
+        %around z and couch rotates counter-clockwise around y
+        
+        %active, counter-clockwise rotation Matrix for Gantry around z 
+        %with pre-multiplication of the matrix (R*x)
+        %Note: Gantry rotation is physically an active rotation of a beam 
+        %vector around the target / isocenterin the patient coordinate
+        %system
+        R_Gantry = [cosd(gantryAngle)  -sind(gantryAngle)  0; ...
+            sind(gantryAngle)    cosd(gantryAngle)  0; ...
+            0                            0           1];
+        
+        %active, counter-clockwise rotation for couch around y
+        %with pre-multiplication of the matrix (R*x)
+        %Note: Couch rotation is physically a passive rotation of the 
+        %patient system around the beam target point / isocenter
+        R_Couch = [cosd(couchAngle) 0 sind(couchAngle); ...
+            0 1 0; ...
+            -sind(couchAngle)    0    cosd(couchAngle)];
+    otherwise
+        error('matRad only supports LPS system so far');
+end
+
+switch type
+    case 'both'
+        %Since the couch rotation is physically a passive rotation of the
+        %system, we perform it first and then rotate the gantry
+        rotMat = R_Couch*R_Gantry;
+    case 'gantry'
+        rotMat = R_Gantry;
+    case 'couch'
+        rotMat = R_Couch;
+    otherwise
+        error(['Rotation matrix ''' type ''' not known, needs to be ''full'', ''gantry'' or ''couch''']);       
+end
+
+end
+

--- a/matRad_getRotationMatrix.m
+++ b/matRad_getRotationMatrix.m
@@ -91,7 +91,7 @@ switch system
 end
 
 switch type
-    case 'both'
+    case 'full'
         %Since the couch rotation is physically a passive rotation of the
         %system, we perform it first and then rotate the gantry
         rotMat = R_Couch*R_Gantry;

--- a/matRad_getRotationMatrix.m
+++ b/matRad_getRotationMatrix.m
@@ -1,6 +1,11 @@
 function rotMat = matRad_getRotationMatrix(arg1,arg2,type,system)
-% matRad function to return the rotation / transformation matrix for various
-% scenarios according to IEC 61217.
+% matRad function to return the rotation / transformation matrix for
+% gantry and/or couch rotation. The Rotation matrix stands for a (1)
+% counter-clockwise, (2) active rotation in the patient coordinate system
+% that is performed on a (4) column vector (by premultiplying the matrix). 
+% Per change of one of these directions a matrix transpose of the returned 
+% matrix is required.
+% 
 % 
 % call
 %  rotMat = matRad_getRotationMatrix(gantryAngle,couchAngle,type,system)
@@ -21,8 +26,8 @@ function rotMat = matRad_getRotationMatrix(arg1,arg2,type,system)
 %                   supported (right handed system).
 %
 % output
-%   rotMat:         3x3 matrix that performs a rotation around the patient
-%                   via rotMat * x
+%   rotMat:         3x3 matrix that performs an active rotation around the 
+%                   patient system origin via rotMat * x
 %
 % References
 %   -

--- a/matRad_getRotationMatrix.m
+++ b/matRad_getRotationMatrix.m
@@ -1,4 +1,4 @@
-function rotMat = matRad_getRotationMatrix(arg1,arg2,type,system)
+function rotMat = matRad_getRotationMatrix(gantryAngle,couchAngle,system)
 % matRad function to return the rotation / transformation matrix for
 % gantry and/or couch rotation. The Rotation matrix stands for a (1)
 % counter-clockwise, (2) active rotation in the patient coordinate system
@@ -9,18 +9,11 @@ function rotMat = matRad_getRotationMatrix(arg1,arg2,type,system)
 % 
 % call
 %  rotMat = matRad_getRotationMatrix(gantryAngle,couchAngle,type,system)
-%  rotMat = matRad_getRotationMatrix(pln,fieldIx,type,system)
 %
 % input
 %   gantryAngle:    beam/gantry angle
 %   couchAngle:     couch angle 
-%   or  
-%   pln:            matRad plan meta information struct
-%   fieldIx:        index of the field / beam that is requested
-%   
-%   type:       optional parameter. Can be 'full' (both rotations as
-%                   matrix, default) or 'gantry' / 'couch' for the 
-%                   individual matrices
+%
 %   system:         optional coordinate system the transformation matrix is
 %                   requested for. So far, only the default option 'LPS' is
 %                   supported (right handed system).
@@ -30,7 +23,7 @@ function rotMat = matRad_getRotationMatrix(arg1,arg2,type,system)
 %                   patient system origin via rotMat * x
 %
 % References
-%   -
+%   https://en.wikipedia.org/wiki/Rotation_matrix (2017, Mar 1)
 %
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -48,25 +41,12 @@ function rotMat = matRad_getRotationMatrix(arg1,arg2,type,system)
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %% Parse arguments
-%We need at least two and max 6 input arguments
-narginchk(2,4);
-%check if a pln and index have been given
-if isstruct(arg1)
-    pln = arg1;
-    fieldIx = arg2;
-    gantryAngle = pln.gantryAngles(fieldIx);
-    couchAngle = pln.couchAngles(fieldIx);
-else
-    gantryAngle = arg1;
-    couchAngle = arg2;
-end 
+%We need at least two and max 3 input arguments
+narginchk(2,3);
+
 % Coordinate System (only LPS so far)
-if nargin < 4
-    system = 'LPS';
-end
-%Gantry, Couch, or full transformation?
 if nargin < 3
-    type = 'full';
+    system = 'LPS';
 end
 
 %% Set Up requested Rotation Matrix
@@ -95,18 +75,7 @@ switch system
         error('matRad only supports LPS system so far');
 end
 
-switch type
-    case 'full'
-        %Since the couch rotation is physically a passive rotation of the
-        %system, we perform it first and then rotate the gantry
-        rotMat = R_Couch*R_Gantry;
-    case 'gantry'
-        rotMat = R_Gantry;
-    case 'couch'
-        rotMat = R_Couch;
-    otherwise
-        error(['Rotation matrix ''' type ''' not known, needs to be ''full'', ''gantry'' or ''couch''']);       
-end
+rotMat = R_Couch*R_Gantry;
 
 end
 

--- a/matRad_rayTracing.m
+++ b/matRad_rayTracing.m
@@ -83,18 +83,11 @@ rayMx_bev = [candidateRaysCoords_X(logical(candidateRayMx(:))) ...
 %        plot(rayMx_bev(jj,1),rayMx_bev(jj,3),'rx'),hold on 
 %     end
 
-% Rotation around Z axis (gantry)
-rotMx_XY_T = [ cosd(stf.gantryAngle) sind(stf.gantryAngle) 0;
-              -sind(stf.gantryAngle) cosd(stf.gantryAngle) 0;
-                                   0                     0 1];
-    
-% Rotation around Y axis (couch)
-rotMx_XZ_T = [cosd(stf.couchAngle) 0 -sind(stf.couchAngle);
-                                 0 1                     0;
-              sind(stf.couchAngle) 0  cosd(stf.couchAngle)];
+% Rotation matrix. Transposed because of row vectors
+rotMat_vectors_T = transpose(matRad_getRotationMatrix(stf.gantryAngle,stf.couchAngle));
 
 % rotate ray matrix from bev to world coordinates
-rayMx_world = rayMx_bev * rotMx_XY_T * rotMx_XZ_T;
+rayMx_world = rayMx_bev * rotMat_vectors_T;
 
 % criterium for ray selection
 raySelection = rayMxSpacing/2;


### PR DESCRIPTION
Removal of the hard-coded rotation matrices within the code. 

matRad_getRotationMatrix(...) now bundles the hard-coded matrices for a fixed scenario (active vector rotation by R*x).

Either the full transformation or the gantry/couch subrotations can be queried.

Added some framework to introduce other coordinate systems at a later stage.

One more check of the changed dicom import by someone else would be nice.