### PR TITLE
Add support for multiple and nonequal isoCenter

### DIFF
--- a/dicomImport/matRad_importDicomRTPlan.m
+++ b/dicomImport/matRad_importDicomRTPlan.m
@@ -77,26 +77,20 @@ end
 % loop over beams
 gantryAngles{length(BeamSeqNames)} = [];
 PatientSupportAngle{length(BeamSeqNames)} = [];
-isoCenter{length(BeamSeqNames)} = [];
+isoCenter = NaN*ones(length(BeamSeqNames),3); 
 for i = 1:length(BeamSeqNames)   
     currBeamSeq             = BeamSequence.(BeamSeqNames{i});
     % parameters not changing are stored in the first ControlPointSequence
     gantryAngles{i}         = currBeamSeq.(ControlParam).Item_1.GantryAngle;
     PatientSupportAngle{i}  = currBeamSeq.(ControlParam).Item_1.PatientSupportAngle;
-    isoCenter{i}            = currBeamSeq.(ControlParam).Item_1.IsocenterPosition;
-end
-
-% check wether isocenters are consistent
-if numel(isoCenter) > 1
-    if ~isequal(isoCenter{:})
-       errordlg('Values for isocenter are not consistent.')
-    end
+    isoCenter(i,:)          = currBeamSeq.(ControlParam).Item_1.IsocenterPosition'; 
 end
 
 % transform iso. At the moment just this way for HFS
 if ct.dicomInfo.ImageOrientationPatient == [1;0;0;0;1;0]
-    isoCenter = isoCenter{1}' - ct.dicomInfo.ImagePositionPatient' + ...
-                         [ct.resolution.x ct.resolution.y ct.resolution.z];
+    isoCenter = isoCenter - ones(length(BeamSeqNames),1) * ...
+        ([ct.x(1) ct.y(1) ct.z(1)] - [ct.resolution.x ct.resolution.y ct.resolution.z]);  
+
 else
     error('This Orientation is not yet supported.');
 end

--- a/dicomImport/matRad_importDicomSteeringParticles.m
+++ b/dicomImport/matRad_importDicomSteeringParticles.m
@@ -114,7 +114,7 @@ for i = 1:length(BeamSeqNames)
     stf(i).radiationMode = pln.radiationMode;
     % there might be several SAD's, e.g. compensator?
     stf(i).SAD           = machine.meta.SAD;
-    stf(i).isoCenter     = pln.isoCenter;
+    stf(i).isoCenter     = pln.isoCenter(i,:);
     stf(i).sourcePoint_bev = [0 -stf(i).SAD 0];
         % now loop over ControlPointSequences
     ControlPointSeqNames = fieldnames(ControlPointSeq);

--- a/dicomImport/matRad_importDicomSteeringPhotons.m
+++ b/dicomImport/matRad_importDicomSteeringPhotons.m
@@ -49,7 +49,7 @@ for i = 1:size(UniqueComb,1)
     % set necessary steering information 
     stf(i).gantryAngle  = UniqueComb(i,1);
     stf(i).couchAngle   = UniqueComb(i,2);
-    stf(i).isoCenter    = pln.isoCenter;
+    stf(i).isoCenter    = pln.isoCenter(i,:);
     
     % bixelWidth = 'field' as keyword for whole field dose calc
     stf(i).bixelWidth    = 'field';

--- a/matRad.m
+++ b/matRad.m
@@ -28,7 +28,7 @@ load TG119.mat
 %load BOXPHANTOM.mat
 
 % meta information for treatment plan
-pln.isoCenter       = matRad_getIsoCenter(cst,ct,0);
+pln.isoCenter       = ones(pln.numOfBeams,1) * matRad_getIsoCenter(cst,ct,0);
 pln.bixelWidth      = 5; % [mm] / also corresponds to lateral spot spacing for particles
 pln.gantryAngles    = [0:72:359]; % [°]
 pln.couchAngles     = [0 0 0 0 0]; % [°]

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -2266,6 +2266,7 @@ if isfield(pln,'isoCenter')
     else
         set(handles.editIsoCenter,'String','multiple isoCenter');
         set(handles.editIsoCenter,'Enable','off');
+        set(handles.checkIsoCenter,'Value',0);
         set(handles.checkIsoCenter,'Enable','off');
     end
 end

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -463,6 +463,9 @@ end
 if exist('stf','var')
     assignin('base','stf',stf);
 end
+if exist('pln','var')
+    assignin('base','pln',pln);
+end
 if exist('dij','var')
     assignin('base','dij',dij);
 end

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -1044,7 +1044,7 @@ elseif plane == 1 % Coronal plane
     end
 end
 
-if get(handles.radioBtnIsoCenter,'Value') == 1 && get(handles.popupTypeOfPlot,'Value') == 1 && ~isempty(pln)
+if get(handles.radioBtnIsoCenter,'Value') == 1 && get(handles.popupTypeOfPlot,'Value') == 1 && ~isempty(pln) && size(pln.isoCenter,1) == 1
     hIsoCenterCross = matRad_plotIsoCenterMarker(handles.axesFig,pln,ct,plane,slice);
 end
 
@@ -2250,7 +2250,15 @@ set(handles.editBixelWidth,'String',num2str(pln.bixelWidth));
 set(handles.editFraction,'String',num2str(pln.numOfFractions));
 
 if isfield(pln,'isoCenter')
-    set(handles.editIsoCenter,'String',regexprep(num2str((round(pln.isoCenter(1,:)*10))./10), '\s+', ' '));
+    if size(pln.isoCenter, 1) == 1
+        set(handles.editIsoCenter,'String',regexprep(num2str((round(pln.isoCenter(1,:)*10))./10), '\s+', ' '));
+        set(handles.editIsoCenter,'Enable','on');
+        set(handles.checkIsoCenter,'Enable','on');
+    else
+        set(handles.editIsoCenter,'String','multiple isoCenter');
+        set(handles.editIsoCenter,'Enable','off');
+        set(handles.checkIsoCenter,'Enable','off');
+    end
 end
 set(handles.editGantryAngle,'String',num2str((pln.gantryAngles)));
 set(handles.editCouchAngle,'String',num2str((pln.couchAngles)));

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -2451,7 +2451,8 @@ pln.runDAO = logical(get(handles.btnRunDAO,'Value'));
 
 try
     cst = evalin('base','cst');
-    if sum(strcmp('TARGET',cst(:,3))) > 0 && get(handles.checkIsoCenter,'Value')
+    if (sum(strcmp('TARGET',cst(:,3))) > 0 && get(handles.checkIsoCenter,'Value')) || ...
+            (sum(strcmp('TARGET',cst(:,3))) > 0 && ~isfield(pln,'isoCenter'))
        pln.isoCenter = ones(pln.numOfBeams,1) * matRad_getIsoCenter(cst,ct);
        set(handles.checkIsoCenter,'Value',1);
     else

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -228,8 +228,14 @@ end
 
 %set plan if available - if not create one
 try 
-     if ismember('pln',AllVarNames)  && handles.State > 0 
-          setPln(handles); 
+     if ismember('pln',AllVarNames)  && handles.State > 0
+          % sanity check of isoCenter
+          if size(pln.isoCenter,1) ~= pln.numOfBeams && size(pln.isoCenter,1) == 1
+              pln.isoCenter = ones(pln.numOfBeams,1) * pln.isoCenter(1,:);
+          elseif size(pln.isoCenter,1) ~= pln.numOfBeams && size(pln.isoCenter,1) ~= 1
+              error('Isocenter in plan file are incosistent.');
+          end
+          setPln(handles);
      elseif handles.State > 0 
           getPlnFromGUI(handles);
           setPln(handles);

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -203,6 +203,7 @@ handles.dispWindow             = cell(3,2); % first dimension refers to the sele
 
 % do not calculate / suggest isoCenter new by default
 set(handles.checkIsoCenter, 'Value', 0);
+set(handles.editIsoCenter,'Enable','on')
 
 % suppose no ct cube in HU is available (because no ct could be available)
 handles.cubeHUavailable = false;

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -2250,7 +2250,7 @@ set(handles.editBixelWidth,'String',num2str(pln.bixelWidth));
 set(handles.editFraction,'String',num2str(pln.numOfFractions));
 
 if isfield(pln,'isoCenter')
-    set(handles.editIsoCenter,'String',regexprep(num2str((round(pln.isoCenter*10))./10), '\s+', ' '));
+    set(handles.editIsoCenter,'String',regexprep(num2str((round(pln.isoCenter(1,:)*10))./10), '\s+', ' '));
 end
 set(handles.editGantryAngle,'String',num2str((pln.gantryAngles)));
 set(handles.editCouchAngle,'String',num2str((pln.couchAngles)));

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -1099,7 +1099,7 @@ if get(handles.popupTypeOfPlot,'Value') == 2 && exist('Result','var')
     rotTargetPointBEV = targetPointBEV * rotMat_system_T;
     
     % perform raytracing on the central axis of the selected beam
-    [~,l,rho,~,ix] = matRad_siddonRayTracer(pln.isoCenter,ct.resolution,rotSourcePointBEV,rotTargetPointBEV,{ct.cube{1}});
+    [~,l,rho,~,ix] = matRad_siddonRayTracer(pln.isoCenter(handles.selectedBeam),ct.resolution,rotSourcePointBEV,rotTargetPointBEV,{ct.cube{1}});
     d = [0 l .* rho{1}];
     % Calculate accumulated d sum.
     vX = cumsum(d(1:end-1));

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -731,7 +731,7 @@ try
     %% check if isocenter is already set
     if ~isfield(pln,'isoCenter')
         handles = showWarning(handles,warning('no iso center set - using center of gravity based on structures defined as TARGET'));
-        pln.isoCenter = matRad_getIsoCenter(evalin('base','cst'),evalin('base','ct'));
+        pln.isoCenter = ones(pln.numOfBeams,1) * matRad_getIsoCenter(evalin('base','cst'),evalin('base','ct'));
         assignin('base','pln',pln);
     elseif ~get(handles.checkIsoCenter,'Value') 
         pln.isoCenter = ones(pln.numOfBeams,1)*str2num(get(handles.editIsoCenter,'String'));
@@ -1105,7 +1105,7 @@ if get(handles.popupTypeOfPlot,'Value') == 2 && exist('Result','var')
     rotTargetPointBEV = targetPointBEV * rotMat_system_T;
     
     % perform raytracing on the central axis of the selected beam
-    [~,l,rho,~,ix] = matRad_siddonRayTracer(pln.isoCenter(handles.selectedBeam),ct.resolution,rotSourcePointBEV,rotTargetPointBEV,{ct.cube{1}});
+    [~,l,rho,~,ix] = matRad_siddonRayTracer(pln.isoCenter(handles.selectedBeam,:),ct.resolution,rotSourcePointBEV,rotTargetPointBEV,{ct.cube{1}});
     d = [0 l .* rho{1}];
     % Calculate accumulated d sum.
     vX = cumsum(d(1:end-1));
@@ -2444,9 +2444,9 @@ pln.runDAO = logical(get(handles.btnRunDAO,'Value'));
 try
     cst = evalin('base','cst');
     if sum(strcmp('TARGET',cst(:,3))) > 0 && get(handles.checkIsoCenter,'Value')
-       pln.isoCenter = ones(pln.numOfBeams,1)*matRad_getIsoCenter(cst,ct); 
+       pln.isoCenter = ones(pln.numOfBeams,1) * matRad_getIsoCenter(cst,ct); 
     else
-       pln.isoCenter = ones(pln.numOfBeams,1)*str2num(get(handles.editIsoCenter,'String'));
+       pln.isoCenter = ones(pln.numOfBeams,1) * str2num(get(handles.editIsoCenter,'String'));
     end
 catch
     warning('couldnt set isocenter in getPln function')
@@ -2813,7 +2813,7 @@ if evalin('base','exist(''pln'',''var'')') && ...
     % change isocenter if that was changed and do _not_ recreate steering
     % information
     for i = 1:numel(pln.gantryAngles)
-        stf(i).isoCenter = pln.isoCenter;
+        stf(i).isoCenter = pln.isoCenter(i,:);
     end
 
     % recalculate influence matrix

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -267,7 +267,7 @@ if handles.State == 3
 end
 
 %per default the first beam is selected for the profile plot
-handles.SelectedBeam = 1;
+handles.selectedBeam = 1;
 handles.plane = get(handles.popupPlane,'Value');
 handles.DijCalcWarning = false;
 
@@ -1085,7 +1085,7 @@ if get(handles.popupTypeOfPlot,'Value') == 2 && exist('Result','var')
     
     % Rotate the system into the beam. 
     % passive rotation & row vector multiplication & inverted rotation requires triple matrix transpose                  
-    rotMat_system_T = transpose(matRad_getRotationMatrix(pln.gantryAngles(handles.SelectedBeam),pln.couchAngles(handles.SelectedBeam)));
+    rotMat_system_T = transpose(matRad_getRotationMatrix(pln.gantryAngles(handles.selectedBeam),pln.couchAngles(handles.selectedBeam)));
     
     if strcmp(handles.ProfileType,'longitudinal')
         sourcePointBEV = [handles.profileOffset -SAD   0];
@@ -1198,7 +1198,7 @@ if get(handles.popupTypeOfPlot,'Value') == 2 && exist('Result','var')
     end
     
     str = sprintf('profile plot - central axis of %d beam gantry angle %d? couch angle %d?',...
-        handles.SelectedBeam ,pln.gantryAngles(handles.SelectedBeam),pln.couchAngles(handles.SelectedBeam));
+        handles.selectedBeam ,pln.gantryAngles(handles.selectedBeam),pln.couchAngles(handles.selectedBeam));
     h_title = title(handles.axesFig,str,'FontSize',defaultFontSize);
     pos = get(h_title,'Position');
     set(h_title,'Position',[pos(1)-40 pos(2) pos(3)])
@@ -1392,7 +1392,7 @@ try
     else
         handles.SelectedDisplayOption = 'physicalDose';
     end
-    handles.SelectedBeam = 1;
+    handles.selectedBeam = 1;
     % check IPOPT status and return message for GUI user if no DAO or
     % particles
     if ~pln.runDAO || ~strcmp(pln.radiationMode,'photons')
@@ -1511,15 +1511,15 @@ elseif get(hObject,'Value') == 2
         if length(parseStringAsNum(get(handles.editGantryAngle,'String'),true)) > 1
             
             set(handles.sliderBeamSelection,'Enable','on');
-            handles.SelectedBeam = 1;
+            handles.selectedBeam = 1;
             pln = evalin('base','pln');
-            set(handles.sliderBeamSelection,'Min',handles.SelectedBeam,'Max',pln.numOfBeams,...
-                'Value',handles.SelectedBeam,...
+            set(handles.sliderBeamSelection,'Min',handles.selectedBeam,'Max',pln.numOfBeams,...
+                'Value',handles.selectedBeam,...
                 'SliderStep',[1/(pln.numOfBeams-1) 1/(pln.numOfBeams-1)],...
                 'Enable','on');
 
         else
-            handles.SelectedBeam = 1;
+            handles.selectedBeam = 1;
         end
     
         handles.profileOffset = get(handles.sliderOffset,'Value');
@@ -1591,8 +1591,8 @@ function sliderBeamSelection_Callback(hObject, ~, handles)
 %        get(hObject,'Min') and get(hObject,'Max') to determine range of slider
 
 
-handles.SelectedBeam = round(get(hObject,'Value'));
-set(hObject, 'Value', handles.SelectedBeam);
+handles.selectedBeam = round(get(hObject,'Value'));
+set(hObject, 'Value', handles.selectedBeam);
 handles.rememberCurrAxes = false;
 UpdatePlot(handles);
 handles.rememberCurrAxes = true;

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -232,12 +232,6 @@ end
 %set plan if available - if not create one
 try 
      if ismember('pln',AllVarNames)  && handles.State > 0
-          % sanity check of isoCenter
-          if size(pln.isoCenter,1) ~= pln.numOfBeams && size(pln.isoCenter,1) == 1
-              pln.isoCenter = ones(pln.numOfBeams,1) * pln.isoCenter(1,:);
-          elseif size(pln.isoCenter,1) ~= pln.numOfBeams && size(pln.isoCenter,1) ~= 1
-              error('Isocenter in plan file are incosistent.');
-          end
           setPln(handles);
      elseif handles.State > 0 
           getPlnFromGUI(handles);
@@ -2255,6 +2249,12 @@ guidata(handles.figure1,handles);
 % fill GUI elements with plan information
 function setPln(handles)
 pln = evalin('base','pln');
+% sanity check of isoCenter
+if size(pln.isoCenter,1) ~= pln.numOfBeams && size(pln.isoCenter,1) == 1
+  pln.isoCenter = ones(pln.numOfBeams,1) * pln.isoCenter(1,:);
+elseif size(pln.isoCenter,1) ~= pln.numOfBeams && size(pln.isoCenter,1) ~= 1
+  error('Isocenter in plan file are incosistent.');
+end
 set(handles.editBixelWidth,'String',num2str(pln.bixelWidth));
 set(handles.editFraction,'String',num2str(pln.numOfFractions));
 

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -2423,6 +2423,12 @@ msgbox(['IPOPT finished with status ' num2str(info.status) ' (' statusmsg ')'],'
 % get pln file form GUI     
 function getPlnFromGUI(handles)
 
+% evalin pln (if existent) in order to decide whether isoCenter should be calculated
+% automatically
+if evalin('base','exist(''pln'',''var'')')
+    pln = evalin('base','pln');
+end
+
 pln.bixelWidth      = parseStringAsNum(get(handles.editBixelWidth,'String'),false); % [mm] / also corresponds to lateral spot spacing for particles
 pln.gantryAngles    = parseStringAsNum(get(handles.editGantryAngle,'String'),true); % [???]
 pln.couchAngles     = parseStringAsNum(get(handles.editCouchAngle,'String'),true); % [???]

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -2322,8 +2322,8 @@ function btnTableSave_Callback(~, ~, handles)
 getCstTable(handles);
 if get(handles.checkIsoCenter,'Value')
     pln = evalin('base','pln'); 
-    pln.isoCenter = matRad_getIsoCenter(evalin('base','cst'),evalin('base','ct')); 
-    set(handles.editIsoCenter,'String',regexprep(num2str((round(pln.isoCenter*10))./10), '\s+', ' '));
+    pln.isoCenter = ones(pln.numOfBeams,1) * matRad_getIsoCenter(evalin('base','cst'),evalin('base','ct')); 
+    set(handles.editIsoCenter,'String',regexprep(num2str((round(pln.isoCenter(1,:) * 10))./10), '\s+', ' '));
     assignin('base','pln',pln);
 end
 getPlnFromGUI(handles);

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -2452,7 +2452,8 @@ pln.runDAO = logical(get(handles.btnRunDAO,'Value'));
 try
     cst = evalin('base','cst');
     if sum(strcmp('TARGET',cst(:,3))) > 0 && get(handles.checkIsoCenter,'Value')
-       pln.isoCenter = ones(pln.numOfBeams,1) * matRad_getIsoCenter(cst,ct); 
+       pln.isoCenter = ones(pln.numOfBeams,1) * matRad_getIsoCenter(cst,ct);
+       set(handles.checkIsoCenter,'Value',1);
     else
        pln.isoCenter = ones(pln.numOfBeams,1) * str2num(get(handles.editIsoCenter,'String'));
     end

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -201,6 +201,9 @@ handles.doseOpacity            = 0.6;
 handles.IsoDose.Levels         = 0;
 handles.dispWindow             = cell(3,2); % first dimension refers to the selected
 
+% do not calculate / suggest isoCenter new by default
+set(handles.checkIsoCenter, 'Value', 0);
+
 % suppose no ct cube in HU is available (because no ct could be available)
 handles.cubeHUavailable = false;
 % initial startup finished

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -1044,7 +1044,7 @@ elseif plane == 1 % Coronal plane
     end
 end
 
-if get(handles.radioBtnIsoCenter,'Value') == 1 && get(handles.popupTypeOfPlot,'Value') == 1 && ~isempty(pln) && size(pln.isoCenter,1) == 1
+if get(handles.radioBtnIsoCenter,'Value') == 1 && get(handles.popupTypeOfPlot,'Value') == 1 && ~isempty(pln) && isequal(unique(pln.isoCenter,'rows') == pln.isoCenter, ones(size(pln.isoCenter)))
     hIsoCenterCross = matRad_plotIsoCenterMarker(handles.axesFig,pln,ct,plane,slice);
 end
 
@@ -2250,7 +2250,7 @@ set(handles.editBixelWidth,'String',num2str(pln.bixelWidth));
 set(handles.editFraction,'String',num2str(pln.numOfFractions));
 
 if isfield(pln,'isoCenter')
-    if size(pln.isoCenter, 1) == 1
+    if isequal(unique(pln.isoCenter,'rows') == pln.isoCenter, ones(size(pln.isoCenter)))
         set(handles.editIsoCenter,'String',regexprep(num2str((round(pln.isoCenter(1,:)*10))./10), '\s+', ' '));
         set(handles.editIsoCenter,'Enable','on');
         set(handles.checkIsoCenter,'Enable','on');

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -2423,7 +2423,7 @@ msgbox(['IPOPT finished with status ' num2str(info.status) ' (' statusmsg ')'],'
 % get pln file form GUI     
 function getPlnFromGUI(handles)
 
-% evalin pln (if existent) in order to decide whether isoCenter should be calculated
+% evalin pln (if existant) in order to decide whether isoCenter should be calculated
 % automatically
 if evalin('base','exist(''pln'',''var'')')
     pln = evalin('base','pln');

--- a/matRad_generateStf.m
+++ b/matRad_generateStf.m
@@ -115,7 +115,7 @@ for i = 1:length(pln.gantryAngles)
     stf(i).bixelWidth    = pln.bixelWidth;
     stf(i).radiationMode = pln.radiationMode;
     stf(i).SAD           = SAD;
-    stf(i).isoCenter     = pln.isoCenter;
+    stf(i).isoCenter     = pln.isoCenter(i,:);
     
     % Get the (active) rotation matrix. We perform a passive/system 
     % rotation with row vector coordinates, which would introduce two 

--- a/plotting/matRad_plotIsoCenterMarker.m
+++ b/plotting/matRad_plotIsoCenterMarker.m
@@ -34,7 +34,7 @@ function markerHandle = matRad_plotIsoCenterMarker(axesHandle,pln,ct,plane,slice
 %
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-vIsoCenter           = round(pln.isoCenter./[ct.resolution.x ct.resolution.y ct.resolution.z]);
+vIsoCenter           = round(pln.isoCenter(1)./[ct.resolution.x ct.resolution.y ct.resolution.z]);
 if  plane == 3% Axial plane
     vIsoCenterPlot  = [vIsoCenter(1) vIsoCenter(2)];
     if vIsoCenter(3) == slice

--- a/plotting/matRad_plotIsoCenterMarker.m
+++ b/plotting/matRad_plotIsoCenterMarker.m
@@ -34,7 +34,7 @@ function markerHandle = matRad_plotIsoCenterMarker(axesHandle,pln,ct,plane,slice
 %
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-vIsoCenter           = round(pln.isoCenter(1)./[ct.resolution.x ct.resolution.y ct.resolution.z]);
+vIsoCenter           = round(pln.isoCenter(1,:)./[ct.resolution.x ct.resolution.y ct.resolution.z]);
 if  plane == 3% Axial plane
     vIsoCenterPlot  = [vIsoCenter(1) vIsoCenter(2)];
     if vIsoCenter(3) == slice
@@ -101,4 +101,3 @@ end
 
 
 end
-


### PR DESCRIPTION
As @markbangert proposed in currently opened pull request.
Added some GUI changes (only code).
I thought we just disable the isoCenter textfield and isoCenter marker when we have more than one isoCenter, for the latter because it might be confusing with more than one cross, any thoughts about that?