### PR TITLE
fixed calcQualityIndicators for the case cst{1,4}{1} = [ ]

### DIFF
--- a/matRad_calcQualityIndicators.m
+++ b/matRad_calcQualityIndicators.m
@@ -54,6 +54,7 @@ else
 end
     
 % calculate QIs per VOI
+qi = struct;
 for runVoi = 1:size(cst,1)
     
     indices     = cst{runVoi,4}{1};


### PR DESCRIPTION
... if no voxels are assigned to first VOI.
There was the error message 'Undefined function or variable 'qi'.'