### PR TITLE
Bugfixes in multScen, minor bugfixes in calcParticleDose

### DIFF
--- a/matRad_calcParticleDose.m
+++ b/matRad_calcParticleDose.m
@@ -62,7 +62,7 @@ end
 ct = matRad_calcWaterEqD(ct, pln, param);
 
 % meta information for dij
-dij.numOfBeams         = pln.propStf.numOfBeams;
+dij.numOfBeams         = numel(stf);
 dij.numOfVoxels        = prod(ct.cubeDim);
 dij.resolution         = ct.resolution;
 dij.dimensions         = ct.cubeDim;
@@ -271,7 +271,7 @@ for ShiftScen = 1:pln.multScen.totNumShiftScen
     % compute SSDs
     stf = matRad_computeSSD(stf,ct,ctScen,param);
 
-   for i = 1:dij.numOfBeams % loop over all beams
+   for i = 1:numel(stf) % loop over all beams
 
        matRad_dispToConsole(['Beam ' num2str(i) ' of ' num2str(dij.numOfBeams) ':  \n'],param,'info');
 
@@ -295,7 +295,7 @@ for ShiftScen = 1:pln.multScen.totNumShiftScen
        % transformation of the coordinate system need double transpose
 
        % rotation around Z axis (gantry)
-       rotMat_system_T = matRad_getRotationMatrix(pln.propStf.gantryAngles(i),pln.propStf.couchAngles(i));
+       rotMat_system_T = matRad_getRotationMatrix(stf(i).gantryAngle,stf(i).couchAngle);
 
        % Rotate coordinates (1st couch around Y axis, 2nd gantry movement)
        rot_coordsV = coordsV*rotMat_system_T;

--- a/matRad_multScen.m
+++ b/matRad_multScen.m
@@ -347,11 +347,11 @@ classdef matRad_multScen
                     this.absRangeShift = [nomScen linspace(-this.maxAbsRangeShift, this.maxAbsRangeShift, this.numOfRangeShiftScen)];
                 case 'sampled'
                     % relRange
-                    std = this.maxRelRangeShift; meanP = 0;
+                    std = this.rangeRelSD; meanP = 0;
                     rng('shuffle');
                     this.relRangeShift = [nomScen std .* randn(1, this.numOfRangeShiftScen) + meanP];
                     % absRange
-                    std = this.maxAbsRangeShift; meanP = 0;
+                    std = this.rangeAbsSD; meanP = 0;
                     rng('shuffle');
                     this.absRangeShift = [nomScen std .* randn(1, this.numOfRangeShiftScen) + meanP];
                 otherwise

--- a/tools/samplingAnalysis/matRad_calcStudy.m
+++ b/tools/samplingAnalysis/matRad_calcStudy.m
@@ -82,11 +82,13 @@ addpath(fullfile(matRadPath,'tools','samplingAnalysis'));
 % calculate RBExDose
 if ~isfield(pln, 'bioParam')
     if strcmp(pln.radiationMode, 'protons')
-        pln.bioOptimization = 'constRBE_RBExD';
+        pln.bioOptimization = 'RBExD';
+        pln.model = 'constRBE';
     elseif strcmp(pln.radiationMode, 'carbon')
-        pln.bioOptimization = 'LEM_RBExD';
+        pln.bioOptimization = 'RBExD';
+        pln.model = 'LEM';
     end
-    pln.bioParam = matRad_bioModel(pln.radiationMode,pln.bioOptimization);
+    pln.bioParam = matRad_bioModel(pln.radiationMode, pln.bioOptimization, pln.model);
 end
     
 

--- a/tools/samplingAnalysis/setupStudy_template.m
+++ b/tools/samplingAnalysis/setupStudy_template.m
@@ -9,6 +9,9 @@ multScen.shiftSize            = [4.5 4.5 4.5];          % maximum shift [mm]  % 
 multScen.shiftGenType         = 'equidistant';    % equidistant: equidistant shifts, sampled: sample shifts from normal distribution
 multScen.shiftCombType        = 'individual';     % individual:  no combination of shift scenarios;       number of shift scenarios is sum(multScen.numOfShiftScen)
                                                   % permuted:    create every possible shift combination; number of shift scenarios is 8,27,64 ... 
+                                                  % combined: number of shifts in each directions must be the same. only use when shifts are sampled
+
+                                             
 % b) define range error scenarios                                                
 multScen.numOfRangeShiftScen  = 30;                % number of absolute and/or relative range scnearios. 
                                                   % if absolute and relative range scenarios are defined then multScen.rangeCombType defines the resulting number of range scenarios


### PR DESCRIPTION
 Bugfix in multScen. Use standard deviations for range shift std and not max value. Already done this way for isoshifts.

Reduced redundancy in calcParticleDose.