### PR TITLE
adding longitudinalSpotSpacing as parameter - issue #166

### DIFF
--- a/matRad_generateStf.m
+++ b/matRad_generateStf.m
@@ -124,6 +124,11 @@ for i = 1:length(pln.propStf.gantryAngles)
     stf(i).SAD           = SAD;
     stf(i).isoCenter     = pln.propStf.isoCenter(i,:);
     
+    if isfield(pln.propStf, 'longitudinalSpotSpacing')
+        stf(i).longitudinalSpotSpacing = pln.propStf.longitudinalSpotSpacing;
+    end
+    
+    
     % Get the (active) rotation matrix. We perform a passive/system 
     % rotation with row vector coordinates, which would introduce two 
     % inversions / transpositions of the matrix, thus no changes to the
@@ -298,11 +303,12 @@ for i = 1:length(pln.propStf.gantryAngles)
         maxPeakPos  = machine.data(maxEnergy == availableEnergies).peakPos;
         
         % find set of energyies with adequate spacing
-        
-        if strcmp(machine.meta.machine,'Generic')
-            longitudinalSpotSpacing = 1.5; % enforce all entries to be used
-        else
-            longitudinalSpotSpacing = 3;   % default value for all other treatment machines
+        if ~isfield(stf(i), 'longitudinalSpotSpacing')
+            if strcmp(machine.meta.machine,'Generic')
+                longitudinalSpotSpacing = 1.5; % enforce all entries to be used
+            else
+                longitudinalSpotSpacing = 3;   % default value for all other treatment machines
+            end
         end
         
         tolerance              = longitudinalSpotSpacing/10;

--- a/matRad_generateStf.m
+++ b/matRad_generateStf.m
@@ -298,7 +298,7 @@ for i = 1:length(pln.propStf.gantryAngles)
         maxPeakPos  = machine.data(maxEnergy == availableEnergies).peakPos;
         
         % find set of energyies with adequate spacing
-        if ~isfield(stf(i), 'longitudinalSpotSpacing')
+        if ~isfield(pln.propStf, 'longitudinalSpotSpacing')
             if strcmp(machine.meta.machine,'Generic')
                 longitudinalSpotSpacing = 1.5; % enforce all entries to be used
             else

--- a/matRad_generateStf.m
+++ b/matRad_generateStf.m
@@ -123,12 +123,7 @@ for i = 1:length(pln.propStf.gantryAngles)
     stf(i).radiationMode = pln.radiationMode;
     stf(i).SAD           = SAD;
     stf(i).isoCenter     = pln.propStf.isoCenter(i,:);
-    
-    if isfield(pln.propStf, 'longitudinalSpotSpacing')
-        stf(i).longitudinalSpotSpacing = pln.propStf.longitudinalSpotSpacing;
-    end
-    
-    
+        
     % Get the (active) rotation matrix. We perform a passive/system 
     % rotation with row vector coordinates, which would introduce two 
     % inversions / transpositions of the matrix, thus no changes to the
@@ -309,6 +304,8 @@ for i = 1:length(pln.propStf.gantryAngles)
             else
                 longitudinalSpotSpacing = 3;   % default value for all other treatment machines
             end
+        else
+            stf(i).longitudinalSpotSpacing = pln.propStf.longitudinalSpotSpacing;
         end
         
         tolerance              = longitudinalSpotSpacing/10;


### PR DESCRIPTION
I added the `longitudinalSpotSpacing` as a parameter which can be defined in the script to the _pln_ structure which will be passed to the _stf_ structure via `generateStf.m`.

The parameter is optional to define, and in case the user has not defined it, it would assign the original manual input (1.5 for the Generic case and 3 for other cases)

I hope I understood you correctly and this was what you asked for in the issue.