### PR TITLE
*improved rounding (thanks to Zhouping Wei)

### DIFF
--- a/dicomImport/matRad_convRtssContours2Indices.m
+++ b/dicomImport/matRad_convRtssContours2Indices.m
@@ -47,7 +47,7 @@ for i = 1:size(structure.item,2)
         end
     
         round2 = @(a,b) round(a*10^b)/10^b;
-        dicomCtSliceThickness = ct.dicomInfo.SliceThickness(round2(ct.dicomInfo.SlicePositions,0)==round2(dicomCtSlicePos,0));
+        dicomCtSliceThickness = ct.dicomInfo.SliceThickness(round2(ct.dicomInfo.SlicePositions,1)==round2(dicomCtSlicePos,1));
         
         coords1 = interp1(ct.x,1:ct.cubeDim(2),structure.item(i).points(:,1),'linear','extrap');
         coords2 = interp1(ct.y,1:ct.cubeDim(1),structure.item(i).points(:,2),'linear','extrap');


### PR DESCRIPTION
Current code does not work for the following situation:
 ct.dicomInfo.SlicePositions=-4.500 ->rounding will result in 5
dicomCtSlicePos=-4.499                   -> rounding will result in 4