### PR TITLE
*bugfix: use row arrays for bixelWidth to be able to concatenate arrays

### DIFF
--- a/dicomImport/matRad_importDicomSteeringParticles.m
+++ b/dicomImport/matRad_importDicomSteeringParticles.m
@@ -229,7 +229,7 @@ for i = 1:length(BeamSeqNames)
     bixelWidth_help1 = unique(round(1e3*bixelWidth_help(:,1))/1e3,'sorted');
     bixelWidth_help2 = unique(round(1e3*bixelWidth_help(:,2))/1e3,'sorted');
     
-    bixelWidth = unique([unique(diff(bixelWidth_help1)) unique(diff(bixelWidth_help2))]);
+    bixelWidth = unique([unique(diff(bixelWidth_help1))' unique(diff(bixelWidth_help2))']);
     
     if numel(bixelWidth) == 1
         stf(i).bixelWidth = bixelWidth;


### PR DESCRIPTION
For the case of different bixel width: unique(diff(bixelWidth_help1/2)) are column arrays that cannot be concatenated to a row array.