### PR TITLE
bug fix

### DIFF
--- a/matRad_calcPhotonDose.m
+++ b/matRad_calcPhotonDose.m
@@ -117,7 +117,7 @@ end
 doseTmpContainer = cell(numOfBixelsContainer,pln.multScen.numOfCtScen,pln.multScen.totNumShiftScen,pln.multScen.totNumRangeScen);
 
 % Only take voxels inside patient.
-if ~isempty(param.subIx) && param.calcDoseDirect
+if isfield(param, 'subIx') && ~isempty(param.subIx) && param.calcDoseDirect
    V = param.subIx; 
 else
    V = [cst{:,4}];


### PR DESCRIPTION
_param.logLevel_ is used in order to display less output to the console, however, if we define _param.logLevel_, and don't assign _param.subIx_, and use _matRad_calcPhotonDose.m_ we run into error.

so the fix is to simply check if _subIx_ is a field in param before checking if it is empty.