### PR TITLE
Better selection and display of QI / DVH

### DIFF
--- a/matRad_indicatorWrapper.m
+++ b/matRad_indicatorWrapper.m
@@ -64,6 +64,8 @@ figure,set(gcf,'Color',[1 1 1]);
 subplot(2,1,1)
 matRad_showDVH(dvh,cst,pln);
 subplot(2,1,2)
+ixVoi = cellfun(@(c) c.Visible == 1,cst(:,5));
+qi = qi(ixVoi);
 matRad_showQualityIndicators(qi);
 
 

--- a/matRad_showDVH.m
+++ b/matRad_showDVH.m
@@ -40,11 +40,24 @@ end
 % specified
 hold on;
 
-numOfVois = size(cst,1);
+%reduce cst
+visibleIx = cellfun(@(c) c.Visible == 1,cst(:,5));
+cstNames = cst(visibleIx,2);
+cstInfo = cst(visibleIx,5);
+dvh = dvh(visibleIx);
+
+numOfVois = numel(cstNames);
         
 %% print the dvh
-colorMx    = colorcube;
-colorMx    = colorMx(1:floor(64/numOfVois):64,:);
+
+%try to get colors from cst
+try
+    colorMx = cellfun(@(c) c.visibleColor,cstInfo,'UniformOutput',false);
+    colorMx = cell2mat(colorMx);
+catch
+    colorMx    = colorcube;
+    colorMx    = colorMx(1:floor(64/numOfVois):64,:);
+end
 
 lineStyles = {'-',':','--','-.'};
 
@@ -52,18 +65,16 @@ maxDVHvol  = 0;
 maxDVHdose = 0;
 
 for i = 1:numOfVois
-    if cst{i,5}.Visible
-        % cut off at the first zero value where there is no more signal
-        % behind
-        ix      = max([1 find(dvh(i).volumePoints>0,1,'last')]);
-        currDvh = [dvh(i).doseGrid(1:ix);dvh(i).volumePoints(1:ix)];
-        
-        plot(currDvh(1,:),currDvh(2,:),'LineWidth',4,'Color',colorMx(i,:), ...
-            'LineStyle',lineStyles{lineStyleIndicator},'DisplayName',cst{i,2})
-        
-        maxDVHvol  = max(maxDVHvol,max(currDvh(2,:)));
-        maxDVHdose = max(maxDVHdose,max(currDvh(1,:)));
-    end
+    % cut off at the first zero value where there is no more signal
+    % behind
+    ix      = max([1 find(dvh(i).volumePoints>0,1,'last')]);
+    currDvh = [dvh(i).doseGrid(1:ix);dvh(i).volumePoints(1:ix)];
+    
+    plot(currDvh(1,:),currDvh(2,:),'LineWidth',4,'Color',colorMx(i,:), ...
+        'LineStyle',lineStyles{lineStyleIndicator},'DisplayName',cstNames{i})
+    
+    maxDVHvol  = max(maxDVHvol,max(currDvh(2,:)));
+    maxDVHdose = max(maxDVHdose,max(currDvh(1,:)));
 end
 
 fontSizeValue = 14;


### PR DESCRIPTION
These two commits add functionality to
1. - extend the selection of VOIs from the GUI to the qiTable when showed
2. - try to use the same colors for the DVH plot, and fallback to colorcube if not posisble