### PR TITLE
show an error if matRadGUI is started with old cst (non-class based optimization) format.

### DIFF
--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -4252,7 +4252,12 @@ for i = 1:size(cst,1)
    if strcmp(cst(i,3),'IGNORED')~=1
       for j=1:numel(cst{i,6})
            
-           obj = cst{i,6}{j};
+           if ~isstruct(cst{i,6})
+             obj = cst{i,6}{j};
+           else
+             error('Objective in old format!')
+             % write a wrapper to convert to new class based structure
+           end
            
            %Convert to class if not
            if ~isa(obj,'matRad_DoseOptimizationFunction')


### PR DESCRIPTION
show an error if matRadGUI is started with old cst (non-class based optimization) format.