### PR TITLE
Add compatibility to old objective / constraint format

### DIFF
--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -4255,6 +4255,8 @@ for i = 1:size(cst,1)
            cst{i,6} = num2cell(arrayfun(@matRad_DoseOptimizationFunction.convertOldOptimizationStruct,cst{i,6}));
        end
       for j=1:numel(cst{i,6})
+      
+           obj = cst{i,6}{j};
            
            %Convert to class if not
            if ~isa(obj,'matRad_DoseOptimizationFunction')

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -4250,21 +4250,25 @@ cnt = cnt + 1;
 %Create Objectives / Constraints controls
 for i = 1:size(cst,1)   
    if strcmp(cst(i,3),'IGNORED')~=1
+       %Compability Layer for old objective format
+       if isstruct(cst{i,6})
+           cst{i,6} = num2cell(arrayfun(@matRad_DoseOptimizationFunction.convertOldOptimizationStruct,cst{i,6}));
+       end
       for j=1:numel(cst{i,6})
            
-           if ~isstruct(cst{i,6})
-             obj = cst{i,6}{j};
-           else
-             error('Objective in old format!')
-             % write a wrapper to convert to new class based structure
-           end
+          if ~isstruct(cst{i,6})
+              obj = cst{i,6}{j};
+          else
+              %Compability layer
+              obj = cst{i,6}(j);
+          end
            
            %Convert to class if not
            if ~isa(obj,'matRad_DoseOptimizationFunction')
                 try
                     obj = matRad_DoseOptimizationFunction.createInstanceFromStruct(obj);
-                catch
-                    warning('Objective/Constraint not valid!')
+                catch ME
+                    warning('Objective/Constraint not valid!\n%s',ME.message)
                     continue;
                 end
            end

--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -4250,18 +4250,11 @@ cnt = cnt + 1;
 %Create Objectives / Constraints controls
 for i = 1:size(cst,1)   
    if strcmp(cst(i,3),'IGNORED')~=1
-       %Compability Layer for old objective format
+       %Compatibility Layer for old objective format
        if isstruct(cst{i,6})
            cst{i,6} = num2cell(arrayfun(@matRad_DoseOptimizationFunction.convertOldOptimizationStruct,cst{i,6}));
        end
       for j=1:numel(cst{i,6})
-           
-          if ~isstruct(cst{i,6})
-              obj = cst{i,6}{j};
-          else
-              %Compability layer
-              obj = cst{i,6}(j);
-          end
            
            %Convert to class if not
            if ~isa(obj,'matRad_DoseOptimizationFunction')

--- a/matRad_fluenceOptimization.m
+++ b/matRad_fluenceOptimization.m
@@ -42,8 +42,13 @@ cst  = matRad_setOverlapPriorities(cst);
 
 % check & adjust objectives and constraints internally for fractionation 
 for i = 1:size(cst,1)
+    %Compatibility Layer for old objective format
+    if isstruct(cst{i,6})
+        cst{i,6} = num2cell(arrayfun(@matRad_DoseOptimizationFunction.convertOldOptimizationStruct,cst{i,6}));
+    end
     for j = 1:numel(cst{i,6})
-        obj = cst{i,6}{j};
+        
+        obj = cst{i,6}{j};        
         
         %In case it is a default saved struct, convert to object
         %Also intrinsically checks that we have a valid optimization

--- a/optimization/matRad_DoseOptimizationFunction.m
+++ b/optimization/matRad_DoseOptimizationFunction.m
@@ -1,20 +1,20 @@
 classdef (Abstract) matRad_DoseOptimizationFunction
-% matRad_DoseOptimizationFunction This is the superclass for all
-% objectives and constraints to enable easy one-line identification
-%    
-% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%
-% Copyright 2019 the matRad development team. 
-% 
-% This file is part of the matRad project. It is subject to the license 
-% terms in the LICENSE file found in the top-level directory of this 
-% distribution and at https://github.com/e0404/matRad/LICENSES.txt. No part 
-% of the matRad project, including this file, may be copied, modified, 
-% propagated, or distributed except according to the terms contained in the 
-% LICENSE file.
-%
-% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
+    % matRad_DoseOptimizationFunction This is the superclass for all
+    % objectives and constraints to enable easy one-line identification
+    %
+    % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    %
+    % Copyright 2019 the matRad development team.
+    %
+    % This file is part of the matRad project. It is subject to the license
+    % terms in the LICENSE file found in the top-level directory of this
+    % distribution and at https://github.com/e0404/matRad/LICENSES.txt. No part
+    % of the matRad project, including this file, may be copied, modified,
+    % propagated, or distributed except according to the terms contained in the
+    % LICENSE file.
+    %
+    % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    
     properties (Abstract, Constant)
         name                %Display name of the Objective. Needs to be implemented in sub-classes.
         parameterNames      %Cell array of Display names of the parameters. Needs to be implemented in sub-classes.
@@ -70,9 +70,106 @@ classdef (Abstract) matRad_DoseOptimizationFunction
         % creates an optimization function from a struct
         function obj = createInstanceFromStruct(s)
             try
+                %Check vor old version of cst objectives / cosntraints and
+                %convert if necessary
+                if isfield(s,'type')
+                    s = matRad_DoseOptimizationFunction.convertOldOptimizationStruct(s);
+                end
+                
+                %Create objective / constraint from class name
                 obj = eval([s.className '(s)']);
-            catch
-                error(['Input struct / Parameter invalid for creation of optimization function!']);
+                
+            catch ME
+                error(['Could not instantiate Optimization Function: ' ME.message]);
+            end
+        end
+        
+        function s = convertOldOptimizationStruct(old_s)
+            %Converts old version obejctives to current format
+            switch old_s.type
+                %Objectives
+                case 'square deviation'
+                    s.className = 'DoseObjectives.matRad_SquaredDeviation';
+                    s.penalty = old_s.penalty;
+                    s.parameters{1} = old_s.dose;
+                    
+                case 'square overdosing'
+                    s.className = 'DoseObjectives.matRad_SquaredOverdosing';
+                    s.penalty = old_s.penalty;
+                    s.parameters{1} = old_s.dose;
+                    
+                case 'square underdosing'
+                    s.className = 'DoseObjectives.matRad_SquaredUnderdosing';
+                    s.penalty = old_s.penalty;
+                    s.parameters{1} = old_s.dose;
+                    
+                case 'min DVH objective'
+                    s.className = 'DoseObjectives.matRad_MinDVH';
+                    s.parameters{1} = old_s.dose;
+                    s.parameters{2} = old_s.volume;
+                        
+                case 'max DVH objective'
+                    s.className = 'DoseObjectives.matRad_MaxDVH';
+                    s.parameters{1} = old_s.dose;
+                    s.parameters{2} = old_s.volume;
+                    
+                case 'mean'
+                    s.className = 'DoseObjectives.matRad_MeanDose';
+                    s.parameters{1} = old_s.dose;
+                    
+                case 'EUD'
+                    s.className = 'DoseObjectives.matRad_EUD';
+                    s.parameters{1} = old_s.dose;
+                    s.parameters{2} = old_s.EUD;
+                    
+                %Constraints
+                case  'max dose constraint'
+                    s.className = 'DoseConstraints.matRad_MinMaxDose';
+                    s.parameters{1} = 0;
+                    s.parameters{2} = old_s.dose;
+                    
+                case  'min dose constraint'
+                    s.className = 'DoseConstraints.matRad_MinMaxDose';
+                    s.parameters{1} = old_s.dose;
+                    s.parameters{2} = Inf;
+                    
+                case  'min mean dose constraint'
+                    s.className = 'DoseConstraints.matRad_MinMaxMeanDose';
+                    s.parameters{1} = old_s.dose;
+                    s.parameters{2} = Inf;
+                    
+                case  'max mean dose constraint'
+                    s.className = 'DoseConstraints.matRad_MinMaxMeanDose';
+                    s.parameters{1} = 0;
+                    s.parameters{2} = old_s.dose;
+                    
+                    
+                case  'min EUD constraint'
+                    s.className = 'DoseConstraints.matRad_MinMaxEUD';
+                    s.parameters{1} = old_s.EUD;
+                    s.parameters{2} = old_s.dose;
+                    s.parameters{3} = Inf;
+                    
+                case  'max EUD constraint'
+                    s.className = 'DoseConstraints.matRad_MinMaxEUD';
+                    S.parameters{1} = old_s.EUD;
+                    s.parameters{2} = 0;
+                    s.parameters{3} = old_s.dose;
+                    
+                case  'max DVH constraint'
+                    s.className = 'DoseConstraints.matRad_MinMaxDVH';
+                    s.parameters{1} = old_s.dose;
+                    s.parameters{2} = 0;
+                    s.parameters{3} = old_s.volume;
+                    
+                case  'min DVH constraint'
+                    s.className = 'DoseConstraints.matRad_MinMaxDVH';
+                    s.parameters{1} = old_s.dose;
+                    s.parameters{2} = old_s.volume;
+                    s.parameters{3} = 1;
+                otherwise
+                    ME = MException('optimization:ObjectCreationFailed','Old versioned input struct / parameter invalid for creation of optimization function!');
+                    throw(ME);
             end
         end
     end

--- a/optimization/matRad_DoseOptimizationFunction.m
+++ b/optimization/matRad_DoseOptimizationFunction.m
@@ -166,7 +166,7 @@ classdef (Abstract) matRad_DoseOptimizationFunction
                     s.className = 'DoseConstraints.matRad_MinMaxDVH';
                     s.parameters{1} = old_s.dose;
                     s.parameters{2} = old_s.volume;
-                    s.parameters{3} = 1;
+                    s.parameters{3} = 100;
                 otherwise
                     ME = MException('optimization:ObjectCreationFailed','Old versioned input struct / parameter invalid for creation of optimization function!');
                     throw(ME);

--- a/tools/matRad_convertOldCstToNewCstObjectives.m
+++ b/tools/matRad_convertOldCstToNewCstObjectives.m
@@ -34,104 +34,13 @@ newCst = cst;
 
 % Loop over cst to convert objectives
 for m = 1:size(cst,1)
-    if ~isempty(cst{m,6})
-        
+    if ~isempty(cst{m,6})        
         %Create empty cell array in the new cst
-        newCst{m,6} = cell(0);
-        
+        newCst{m,6} = cell(0);        
         %For each objective instanciate the appropriate objective object
-        for n = 1:numel(cst{m,6})            
-            if isequal(cst{m,6}(n).type,'square deviation')
-                obj = DoseObjectives.matRad_SquaredDeviation;
-                obj.penalty = cst{m,6}(n).penalty;
-                obj.parameters{1} = cst{m,6}(n).dose;
-                newCst{m,6}{n} = obj;
-                
-            elseif isequal(cst{m,6}(n).type,'square overdosing')
-                obj = DoseObjectives.matRad_SquaredOverdosing;
-                obj.penalty = cst{m,6}(n).penalty;
-                obj.parameters{1} = cst{m,6}(n).dose;
-                newCst{m,6}{n} = obj;
-                
-            elseif isequal(cst{m,6}(n).type,'square underdosing')
-                obj = DoseObjectives.matRad_SquaredUnderdosing;
-                obj.penalty = cst{m,6}(n).penalty;
-                obj.parameters{1} = cst{m,6}(n).dose;
-                newCst{m,6}{n} = obj;
-                
-            elseif isequal(cst{m,6}(n).type,'min DVH objective')
-                obj = DoseObjectives.matRad_MinDVH;
-                obj.parameters{1} = cst{m,6}(n).dose;
-                obj.parameters{2} = cst{m,6}(n).volume;
-                newCst{m,6}{n} = obj;
-                
-            elseif isequal(cst{m,6}(n).type,'max DVH objective')
-                obj = DoseObjectives.matRad_MaxDVH;
-                obj.parameters{1} = cst{m,6}(n).dose;
-                obj.parameters{2} = cst{m,6}(n).volume;
-                newCst{m,6}{n} = obj;
-                
-            elseif isequal(cst{m,6}(n).type,'mean')
-                obj = DoseObjectives.matRad_MeanDose;
-                obj.parameters{1} = cst{m,6}(n).dose;
-                newCst{m,6}{n} = obj;
-                
-            elseif isequal(cst{m,6}(n).type,'EUD')
-                obj = DoseObjectives.matRad_EUD;
-                obj.parameters{1} = cst{m,6}(n).dose;
-                obj.parameters{2} = cst{m,6}(n).EUD;                
-                newCst{m,6}{n} = obj;
-            
-            %Constraints
-            elseif isequal(cst{m,6}(n).type, 'max dose constraint')
-                obj = DoseConstraints.matRad_MinMaxDose;
-                obj.parameters{1} = 0;
-                obj.parameters{2} = cst{m,6}(n).dose;
-            
-            elseif isequal(constraint.type, 'min dose constraint')
-                obj = DoseConstraints.matRad_MinMaxDose;
-                obj.parameters{1} = cst{m,6}(n).dose;
-                obj.parameters{2} = Inf;
-
-            elseif isequal(constraint.type, 'min mean dose constraint')
-                obj = DoseConstraints.matRad_MinMaxMeanDose;
-                obj.parameters{1} = cst{m,6}(n).dose;
-                obj.parameters{2} = Inf;
-                
-            elseif isequal(constraint.type, 'max mean dose constraint') 
-                obj = DoseConstraints.matRad_MinMaxMeanDose;
-                obj.parameters{1} = 0;
-                obj.parameters{2} = cst{m,6}(n).dose;
-
-
-            elseif isequal(constraint.type, 'min EUD constraint')
-                obj = DoseConstraints.matRad_MinMaxEUD;
-                obj.parameters{1} = cst{m,6}(n).EUD;
-                obj.parameters{2} = cst{m,6}(n).dose;
-                obj.parameters{3} = Inf;
-                
-            elseif isequal(constraint.type, 'max EUD constraint')
-                obj = DoseConstraints.matRad_MinMaxEUD;
-                obj.parameters{1} = cst{m,6}(n).EUD;
-                obj.parameters{2} = 0;
-                obj.parameters{3} = cst{m,6}(n).dose;
-        
-
-            elseif isequal(constraint.type, 'max DVH constraint')
-                obj = DoseConstraints.matRad_MinMaxDVH;
-                obj.parameters{1} = cst{m,6}(n).dose;
-                obj.parameters{2} = 0;
-                obj.parameters{3} = cst{m,6}(n).volume;
-            
-            elseif isequal(constraint.type, 'min DVH constraint')             
-                obj = DoseConstraints.matRad_MinMaxDVH;
-                obj.parameters{1} = cst{m,6}(n).dose;
-                obj.parameters{2} = cst{m,6}(n).volume;
-                obj.parameters{3} = 1;
-            else
-                warndlg('ERROR. Can not convert CST objectives/constraints.','Loading Error');
-                break;
-            end
+        for n = 1:numel(cst{m,6})
+            s = matRad_DoseOptimizationFunction.convertOldOptimizationStruct(cst{m,6}(n));
+            newCst{m,6}{n} = s;
         end
     end
 end

--- a/tools/matRad_convertOldCstToNewCstObjectives.m
+++ b/tools/matRad_convertOldCstToNewCstObjectives.m
@@ -38,7 +38,7 @@ for m = 1:size(cst,1)
         %Create empty cell array in the new cst
         newCst{m,6} = cell(0);        
         %For each objective instanciate the appropriate objective object
-        for n = 1:numel(cst{m,6})
+        for n = 1:numel(cst{m,6})            
             s = matRad_DoseOptimizationFunction.convertOldOptimizationStruct(cst{m,6}(n));
             newCst{m,6}{n} = s;
         end


### PR DESCRIPTION
This enables compatibility with the old format of objectives & constraints. matRad_DoseOptimizationFunction is now able to instantiate objects also from old structs. Working with the GUI will automatically change the cst in the workspace to the new format.