### PR TITLE
hot fix for optimization gui

### DIFF
--- a/optimization/+DoseConstraints/matRad_DoseConstraint.m
+++ b/optimization/+DoseConstraints/matRad_DoseConstraint.m
@@ -50,9 +50,19 @@ classdef (Abstract) matRad_DoseConstraint < matRad_DoseOptimizationFunction
     methods (Access = public)
        
         % default constructor of matRad_DoseConstraint
-        function obj = matRad_DoseConstraint(inputArg)
+        function obj = matRad_DoseConstraint(s)
             % superclass constructor is already called when this is line is reached
             % additional matRad_DoseConstraint constructor specific code goes here
+            
+            if nargin < 1 || isempty(s) || ~isstruct(s)
+                return;
+            end
+            
+            try
+                obj.parameters = s.parameters;
+            catch ME
+                error('Wrong Initialization of %s. Error Message:\n%s',mfilename,ME.message); 
+            end
         end
         
         function jStruct = getDoseConstraintJacobianStructure(obj,n)

--- a/optimization/+DoseConstraints/matRad_DoseConstraint.m
+++ b/optimization/+DoseConstraints/matRad_DoseConstraint.m
@@ -50,19 +50,9 @@ classdef (Abstract) matRad_DoseConstraint < matRad_DoseOptimizationFunction
     methods (Access = public)
        
         % default constructor of matRad_DoseConstraint
-        function obj = matRad_DoseConstraint(s)
-            % superclass constructor is already called when this is line is reached
-            % additional matRad_DoseConstraint constructor specific code goes here
-            
-            if nargin < 1 || isempty(s) || ~isstruct(s)
-                return;
-            end
-            
-            try
-                obj.parameters = s.parameters;
-            catch ME
-                error('Wrong Initialization of %s. Error Message:\n%s',mfilename,ME.message); 
-            end
+        function obj = matRad_DoseConstraint(varargin)
+            %default initialization from struct (parameters & penalty)
+            obj@matRad_DoseOptimizationFunction(varargin{:});
         end
         
         function jStruct = getDoseConstraintJacobianStructure(obj,n)

--- a/optimization/+DoseObjectives/matRad_DoseObjective.m
+++ b/optimization/+DoseObjectives/matRad_DoseObjective.m
@@ -43,10 +43,21 @@ classdef (Abstract) matRad_DoseObjective < matRad_DoseOptimizationFunction
     
     methods (Access = public)
        
-       % default constructor of matRad_DoseObjective
-        function obj = matRad_DoseObjective(inputArg)
+        % constructor of matRad_DoseObjective
+        function obj = matRad_DoseObjective(s)
             % superclass constructor is already called when this is line is reached
             % additional matRad_DoseObjective constructor specific code goes here
+            
+            if nargin < 1 || isempty(s) || ~isstruct(s)
+                return;
+            end
+            
+            try
+                obj.penalty = s.penalty;
+                obj.parameters = s.parameters;
+            catch ME
+                error('Wrong Initialization of %s. Error Message:\n%s',mfilename,ME.message); 
+            end
         end
         
         %Overloads the struct function to add Objective related information

--- a/optimization/+DoseObjectives/matRad_DoseObjective.m
+++ b/optimization/+DoseObjectives/matRad_DoseObjective.m
@@ -44,20 +44,9 @@ classdef (Abstract) matRad_DoseObjective < matRad_DoseOptimizationFunction
     methods (Access = public)
        
         % constructor of matRad_DoseObjective
-        function obj = matRad_DoseObjective(s)
-            % superclass constructor is already called when this is line is reached
-            % additional matRad_DoseObjective constructor specific code goes here
-            
-            if nargin < 1 || isempty(s) || ~isstruct(s)
-                return;
-            end
-            
-            try
-                obj.penalty = s.penalty;
-                obj.parameters = s.parameters;
-            catch ME
-                error('Wrong Initialization of %s. Error Message:\n%s',mfilename,ME.message); 
-            end
+        function obj = matRad_DoseObjective(varargin)
+            %default initialization from struct (parameters & penalty)
+            obj@matRad_DoseOptimizationFunction(varargin{:});
         end
         
         %Overloads the struct function to add Objective related information


### PR DESCRIPTION
Hotfix for a display problem in the new optimization GUI. Only standard values were shown because of empty superclass constructors. Octave has a problem with assigning properties in the constructor, so I included a workaround.