### PR TITLE
Hotfix to resolve dimension-mess-bug in GUI

### DIFF
--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -212,6 +212,50 @@ handles.initialGuiStart = false;
 guidata(hObject, handles);  
 % eof resetGUI
 
+
+% --- Initializes the slice slider for the current ct & isocenter (or sets
+% it to default)
+function initViewSliceSlider(handles)
+% handles    structure with handles and user data (see GUIDATA)
+
+if handles.State > 0
+    ct = evalin('base', 'ct');
+    
+    %Helpers for managing the resolution and Matlab xy permutation
+    planePermute = [2 1 3];
+    ctRes = [ct.resolution.x ct.resolution.y ct.resolution.z];
+    planePermIx = planePermute(handles.plane);
+    planeDim = ct.cubeDim(handles.plane);   
+
+    %Try to select the slice from defined isocenter
+    try
+        if evalin('base','exist(''pln'',''var'')')
+            currPln = evalin('base','pln');
+            
+            if sum(currPln.propStf.isoCenter(:)) ~= 0
+                %currSlice = round((currPln.propStf.isoCenter(1,planePermIx)+ctRes(planePermix)/2)/ctRes(planePermIx))-1;
+                currSlice = round(currPln.propStf.isoCenter(1,planePermIx) / ctRes(planePermIx));
+            end
+        end
+    catch
+        currSlice = 0; %Set to zero for next if
+    end
+
+    %If no isocenter or wrong value, choose central slice
+    if currSlice < 1 || currSlice > planeDim
+        currSlice = ceil(planeDim/2);
+    end
+
+    set(handles.sliderSlice,'Min',1,'Max',planeDim,...
+        'Value',currSlice,...
+        'SliderStep',[1/(planeDim-1) 1/(planeDim-1)]);
+else
+    % reset slider when nothing is loaded
+    set(handles.sliderSlice,'Min',0,'Max',1,'Value',0,'SliderStep',[1 1]);
+end
+
+
+
 function handles = reloadGUI(hObject, handles, ct, cst)
 AllVarNames = handles.AllVarNames;
 
@@ -282,25 +326,11 @@ handles.selectedBeam = 1;
 handles.plane = get(handles.popupPlane,'Value');
 handles.DijCalcWarning = false;
 
-planePermute = [2 1 3];
-
 % set slice slider
+initViewSliceSlider(handles);
+
+% define context menu for structures
 if handles.State > 0
-    if evalin('base','exist(''pln'',''var'')')
-        currPln = evalin('base','pln');
-        if sum(currPln.propStf.isoCenter(:)) ~= 0
-            currSlice = ceil(currPln.propStf.isoCenter(1,planePermute(handles.plane))/ct.resolution.x);
-        else 
-            currSlice = ceil(ct.cubeDim(planePermute(handles.plane))/2);
-        end
-    else % no pln -> no isocenter -> use middle
-        currSlice = ceil(ct.cubeDim(planePermute(handles.plane))/2);
-    end
-    set(handles.sliderSlice,'Min',1,'Max',ct.cubeDim(handles.plane),...
-            'Value',currSlice,...
-            'SliderStep',[1/(ct.cubeDim(handles.plane)-1) 1/(ct.cubeDim(handles.plane)-1)]);      
-    
-    % define context menu for structures
     for i = 1:size(cst,1)
         if cst{i,5}.Visible
             handles.VOIPlotFlag(i) = true;
@@ -308,9 +338,6 @@ if handles.State > 0
             handles.VOIPlotFlag(i) = false;
         end
     end
-  else
-    % reset slider when nothing is loaded
-    set(handles.sliderSlice,'Min',0,'Max',1,'Value',0,'SliderStep',[1 1]);
 end
 
 %Initialize colormaps and windows
@@ -1044,13 +1071,13 @@ end
 ratios = [1/ct.resolution.x 1/ct.resolution.y 1/ct.resolution.z];
 set(handles.axesFig,'DataAspectRatioMode','manual');
 if plane == 1 
-      res = [ratios(3) ratios(2)]./max([ratios(3) ratios(2)]);  
+      res = [ratios(3) ratios(1)]./max([ratios(3) ratios(1)]);  
       set(handles.axesFig,'DataAspectRatio',[res 1])
 elseif plane == 2 % sagittal plane
-      res = [ratios(3) ratios(1)]./max([ratios(3) ratios(1)]);  
+      res = [ratios(3) ratios(2)]./max([ratios(3) ratios(2)]);  
       set(handles.axesFig,'DataAspectRatio',[res 1]) 
 elseif  plane == 3 % Axial plane
-      res = [ratios(2) ratios(1)]./max([ratios(2) ratios(1)]);  
+      res = [ratios(1) ratios(2)]./max([ratios(1) ratios(2)]);  
       set(handles.axesFig,'DataAspectRatio',[res 1])
 end
 
@@ -1365,29 +1392,8 @@ function popupPlane_Callback(hObject, ~, handles)
 %        contents{get(hObject,'Value')} returns selected item from popupPlane
 
 % set slice slider
-handles.plane = get(handles.popupPlane,'value');
-try
-    if handles.State > 0
-        ct = evalin('base', 'ct');
-        set(handles.sliderSlice,'Min',1,'Max',ct.cubeDim(handles.plane),...
-                'SliderStep',[1/(ct.cubeDim(handles.plane)-1) 1/(ct.cubeDim(handles.plane)-1)]);
-        if handles.State < 3
-            set(handles.sliderSlice,'Value',round(ct.cubeDim(handles.plane)/2));
-        else
-            pln = evalin('base','pln');
-            
-            if handles.plane == 1
-                set(handles.sliderSlice,'Value',ceil(pln.propStf.isoCenter(1,2)/ct.resolution.x));
-            elseif handles.plane == 2
-                set(handles.sliderSlice,'Value',ceil(pln.propStf.isoCenter(1,1)/ct.resolution.y));
-            elseif handles.plane == 3
-                set(handles.sliderSlice,'Value',ceil(pln.propStf.isoCenter(1,3)/ct.resolution.z));
-            end
-            
-        end
-    end
-catch
-end
+handles.plane = get(hObject,'value');
+initViewSliceSlider(handles);
 
 handles.rememberCurrAxes = false;
 UpdatePlot(handles);


### PR DESCRIPTION
See Issue #359 
- fixes a problem with GUI display related to initializing the slice for display from the isocenter, where some dimensionality got mixed up.
- removes code redundancy of this initialization
- fixes some further issues that distort display when resolutions in x & y differ (Correct DataAspectRatio).