### PR TITLE
Fix Positioning of Objectives & Constraints in the Optimization View

### DIFF
--- a/matRadGUI.m
+++ b/matRadGUI.m
@@ -3417,7 +3417,7 @@ try
         cst = evalin('base','cst');
         ct = evalin('base','ct');
         %setCstTable(handles,cst);
-        generateCstTable(hanles,cst);
+        generateCstTable(handles,cst);
         handles.TableChanged = false;
         set(handles.popupTypeOfPlot,'Value',1);
         
@@ -4160,37 +4160,46 @@ cst = updateStructureTable(handles,cst);
 
 cstPanel = handles.uipanel3;
 
-cstPanelPos = getpixelposition(cstPanel);
+%Get units in pixels to to calculate aspect ratio
+cstPanelPosUnit = get(cstPanel,'Units');
+set(cstPanel,'Units','pixels');
+cstPanelPosPix = get(cstPanel,'Position');
+set(cstPanel,'Units',cstPanelPosUnit);
+
+aspectRatio = cstPanelPosPix(3) / cstPanelPosPix(4);
 
 %Parameters for line height
-objHeight = 22;
-lineHeight = 25; %Height of a table line
-fieldSep = 2; %Separation between fields horizontally
-yTopSep = 40; %Separation of the first line from the top
-tableViewHeight = cstPanelPos(4) - yTopSep; %Full height of the view
+objHeight = 0.095;% 22;
+lineHeight = 0.1; %25; %Height of a table line
+yTopSep = 0.12;%40; %Separation of the first line from the top
+tableViewHeight = 1 - yTopSep; 
 
-%Widths of the fields
-buttonW = objHeight;
-nameW = 90;
-typeW = 70;
-opW = objHeight;
-functionW = 120;
-penaltyW = 40;
-paramTitleW = 120;
-paramW = 30;
+%Define the widths of the fields relatively
+buttonW = objHeight / aspectRatio; % Make button squared
+nameW = 3.5*buttonW;
+typeW = 3*buttonW;
+opW = buttonW;
+functionW = 6*buttonW;
+penaltyW = 2*buttonW;
+paramTitleW = 4*buttonW;
+paramW = 2*buttonW;
+fieldSep = 0.25*buttonW; %Separation between fields horizontally
 
 
 %Scrollbar
-cstVertTableScroll = findobj(cstPanel.Children,'Style','slider');
+%Check if a scrollbar already exists to get possible position of slider
+cstPanelChildren = get(cstPanel,'Children');
+cstVertTableScroll = findobj(cstPanelChildren,'Style','slider');
 if isempty(cstVertTableScroll)
     sliderPos = 0;
 else
-    sliderPos = cstVertTableScroll.Max - cstVertTableScroll.Value;
+    sliderPos = get(cstVertTableScroll,'Max') - get(cstVertTableScroll,'Value');
 end
-%disp(num2str(sliderPos));
+
 ypos = @(c) tableViewHeight - c*lineHeight + sliderPos;
 
-delete(cstPanel.Children);
+%Clean the whole panel for new setup
+delete(cstPanelChildren);
 
 %Creates a dummy axis to allow for the use of textboxes instead of uicontrol to be able to use the (la)tex interpreter
 tmpAxes = axes('Parent',cstPanel,'units','normalized','position',[0 0 1 1],'visible','off');
@@ -4217,40 +4226,36 @@ for clIx = 1:numel(classList)
     classNames(:,clIx) = {cl.Name; pName}; %Store class name and display name
 end
 
-% Collect Class-File & Display Names
-%classNames = {classList.Name; p.DefaultValue};
-
-%columnformat = {cst(:,2)',{'OAR','TARGET'},'numeric',...
-%       AllObjectiveFunction,...
-%       'numeric','numeric','numeric','numeric',{'none','WC','prob'}};
-   
-numOfObjectives = 0;
-for i = 1:size(cst,1)
-    if ~isempty(cst{i,6})
-        numOfObjectives = numOfObjectives + numel(cst{i,6});
-    end
-end
+numOfObjectives = sum(cellfun(@numel,cst(:,6)));
 
 cnt = 0;
 
 newline = '\n';
 
 %Setup Headlines
-xPos = 5;
-h = uicontrol(cstPanel,'Style','text','String','+/-','Position',[xPos ypos(cnt) buttonW objHeight],'TooltipString','Remove or add Constraint or Objective');
-xPos = xPos + h.Position(3) + fieldSep;
-h = uicontrol(cstPanel,'Style','text','String','VOI name','Position',[xPos ypos(cnt) nameW objHeight],'TooltipString','Name of the structure with objective/constraint');
-xPos = xPos + h.Position(3) + fieldSep;
-h = uicontrol(cstPanel,'Style','text','String','VOI type','Position',[xPos ypos(cnt) typeW objHeight],'TooltipString','Segmentation Classification');
-xPos = xPos + h.Position(3) + fieldSep;
-h = uicontrol(cstPanel,'Style','text','String','OP','Position',[xPos ypos(cnt) opW objHeight],'TooltipString',['Overlap Priority' char(10) '(Smaller number overlaps higher number)']);
-xPos = xPos + h.Position(3) + fieldSep;
-h = uicontrol(cstPanel,'Style','text','String','Function','Position',[xPos ypos(cnt) functionW objHeight],'TooltipString','Objective/Constraint function type');
-xPos = xPos + h.Position(3) + fieldSep;
-h = uicontrol(cstPanel,'Style','text','String','p','Position',[xPos ypos(cnt) penaltyW objHeight],'TooltipString','Optimization penalty');
-xPos = xPos + h.Position(3) + fieldSep;
-h = uicontrol(cstPanel,'Style','text','String','| Parameters','Position',[xPos ypos(cnt) paramTitleW objHeight],'TooltipString','List of parameters','HorizontalAlignment','left');
-xPos = xPos + h.Position(3) + fieldSep;
+xPos = 0.01; %5
+
+h = uicontrol(cstPanel,'Style','text','String','+/-','Units','normalized','Position',[xPos ypos(cnt) buttonW objHeight],'TooltipString','Remove or add Constraint or Objective');
+tmp_pos = get(h,'Position');
+xPos = xPos + tmp_pos(3) + fieldSep;
+h = uicontrol(cstPanel,'Style','text','String','VOI name','Units','normalized','Position',[xPos ypos(cnt) nameW objHeight],'TooltipString','Name of the structure with objective/constraint');
+tmp_pos = get(h,'Position');
+xPos = xPos + tmp_pos(3) + fieldSep;
+h = uicontrol(cstPanel,'Style','text','String','VOI type','Units','normalized','Position',[xPos ypos(cnt) typeW objHeight],'TooltipString','Segmentation Classification');
+tmp_pos = get(h,'Position');
+xPos = xPos + tmp_pos(3) + fieldSep;
+h = uicontrol(cstPanel,'Style','text','String','OP','Units','normalized','Position',[xPos ypos(cnt) opW objHeight],'TooltipString',['Overlap Priority' char(10) '(Smaller number overlaps higher number)']);
+tmp_pos = get(h,'Position');
+xPos = xPos + tmp_pos(3) + fieldSep;
+h = uicontrol(cstPanel,'Style','text','String','Function','Units','normalized','Position',[xPos ypos(cnt) functionW objHeight],'TooltipString','Objective/Constraint function type');
+tmp_pos = get(h,'Position');
+xPos = xPos + tmp_pos(3) + fieldSep;
+h = uicontrol(cstPanel,'Style','text','String','p','Units','normalized','Position',[xPos ypos(cnt) penaltyW objHeight],'TooltipString','Optimization penalty');
+tmp_pos = get(h,'Position');
+xPos = xPos + tmp_pos(3) + fieldSep;
+h = uicontrol(cstPanel,'Style','text','String','| Parameters','Units','normalized','Position',[xPos ypos(cnt) paramTitleW objHeight],'TooltipString','List of parameters','HorizontalAlignment','left');
+tmp_pos = get(h,'Position');
+xPos = xPos + tmp_pos(3) + fieldSep;
 cnt = cnt + 1;
 
 %Create Objectives / Constraints controls
@@ -4273,87 +4278,82 @@ for i = 1:size(cst,1)
                     continue;
                 end
            end
-               
+
            %VOI
-           %data{Counter,1}  = cst{i,2};
-           %ypos = cstPanelPos(4) - (yTopSep + cnt*lineHeight);
-           xPos = 5;
+           xPos = 0.01;%5;
            
-           %h = uicontrol(cstPanel,'Style','popupmenu','String',cst(:,2)','Position',[xPos ypos 100 objHeight]);
-           %h.Value = i;
-           h = uicontrol(cstPanel,'Style','pushbutton','String','-','Position',[xPos ypos(cnt) buttonW objHeight],'TooltipString','Remove Objective/Constraint','Callback',{@btObjRemove_Callback,handles},...
+           h = uicontrol(cstPanel,'Style','pushbutton','String','-','Units','normalized','Position',[xPos ypos(cnt) buttonW objHeight],'TooltipString','Remove Objective/Constraint','Callback',{@btObjRemove_Callback,handles},...
                'UserData',[i,j]);
-           xPos = xPos + h.Position(3) + fieldSep;
-           h = uicontrol(cstPanel','Style','edit','String',cst{i,2},'Position',[xPos ypos(cnt) nameW objHeight],'TooltipString','Name',...
+           tmp_pos = get(h,'Position');
+           xPos = xPos + tmp_pos(3) + fieldSep;
+           h = uicontrol(cstPanel','Style','edit','String',cst{i,2},'Units','normalized','Position',[xPos ypos(cnt) nameW objHeight],'TooltipString','Name',...
                'Enable','inactive',... %Disable editing of name atm
                'UserData',[i,2],'Callback',{@editCstParams_Callback,handles}); %Callback added, however, editing is disabled atm
-           xPos = xPos + h.Position(3) + fieldSep;
-           h = uicontrol(cstPanel,'Style','popupmenu','String',organTypes','Value',find(strcmp(cst{i,3},organTypes)),'Position',[xPos ypos(cnt) typeW objHeight],'TooltipString','Segmentation Classification',...
+           tmp_pos = get(h,'Position');
+           xPos = xPos + tmp_pos(3) + fieldSep;
+           h = uicontrol(cstPanel,'Style','popupmenu','String',organTypes','Value',find(strcmp(cst{i,3},organTypes)),'Units','normalized','Position',[xPos ypos(cnt) typeW objHeight],'TooltipString','Segmentation Classification',...
                'UserData',[i,3],'Callback',{@editCstParams_Callback,handles});
-           xPos = xPos + h.Position(3) + fieldSep;
-           h = uicontrol(cstPanel,'Style','edit','String',num2str(cst{i,5}.Priority),'Position',[xPos ypos(cnt) opW objHeight],'TooltipString',['Overlap Priority' newline '(Smaller number overlaps higher number)'],...
+           tmp_pos = get(h,'Position');
+           xPos = xPos + tmp_pos(3) + fieldSep;
+           h = uicontrol(cstPanel,'Style','edit','String',num2str(cst{i,5}.Priority),'Units','normalized','Position',[xPos ypos(cnt) opW objHeight],'TooltipString',['Overlap Priority' newline '(Smaller number overlaps higher number)'],...
                'UserData',[i,5],'Callback',{@editCstParams_Callback,handles});
-           xPos = xPos + h.Position(3) + fieldSep;
+           tmp_pos = get(h,'Position');
+           xPos = xPos + tmp_pos(3) + fieldSep;
            
-           h = uicontrol(cstPanel,'Style','popupmenu','String',classNames(2,:)','Value',find(strcmp(obj.name,classNames(2,:))),'Position',[xPos ypos(cnt) functionW objHeight],'TooltipString','Select Objective/Constraint',...
+           h = uicontrol(cstPanel,'Style','popupmenu','String',classNames(2,:)','Value',find(strcmp(obj.name,classNames(2,:))),'Units','normalized','Position',[xPos ypos(cnt) functionW objHeight],'TooltipString','Select Objective/Constraint',...
                'UserData',{[i,j],classNames(1,:)},'Callback',{@changeObjFunction_Callback,handles});
-           xPos = xPos + h.Position(3) + fieldSep;
+           tmp_pos = get(h,'Position');
+           xPos = xPos + tmp_pos(3) + fieldSep;
            
            %Check if we have an objective to display penalty
            if isa(obj,'DoseObjectives.matRad_DoseObjective')
-               h = uicontrol(cstPanel,'Style','edit','String',num2str(obj.penalty),'Position',[xPos ypos(cnt) penaltyW objHeight],'TooltipString','Objective Penalty','UserData',[i,j,0],'Callback',{@editObjParam_Callback,handles});
+               h = uicontrol(cstPanel,'Style','edit','String',num2str(obj.penalty),'Units','normalized','Position',[xPos ypos(cnt) penaltyW objHeight],'TooltipString','Objective Penalty','UserData',[i,j,0],'Callback',{@editObjParam_Callback,handles});
            else
-               h = uicontrol(cstPanel,'Style','edit','String','----','Position',[xPos ypos(cnt) penaltyW objHeight],'Enable','off');
+               h = uicontrol(cstPanel,'Style','edit','String','----','Units','normalized','Position',[xPos ypos(cnt) penaltyW objHeight],'Enable','off');
            end
-           xPos = xPos + h.Position(3) + fieldSep;
+           tmp_pos = get(h,'Position');
+           xPos = xPos + tmp_pos(3) + fieldSep;
            
+           %Iterate through parameters
            for p = 1:numel(obj.parameterNames)
-              %h = uicontrol(cstPanel,'Style','edit','String',obj.parameters{1,p},'Position',[xPos ypos(cnt) 100 objHeight],'Enable','inactive');
-              %xPos = xPos + h.Position(3) + fieldSep;
-              h = text('Parent',tmpAxes,'String',['| ' obj.parameterNames{p} ':'],'VerticalAlignment','middle','units','pix','Position',[xPos ypos(cnt)+lineHeight/2],'Interpreter','tex','FontWeight','normal',...
-                  'FontSize',cstPanel.FontSize,'FontName',cstPanel.FontName,'FontUnits',cstPanel.FontUnits,'FontWeight','normal');%[xPos ypos(cnt) 100 objHeight]);
-              xPos = xPos + h.Extent(3) + fieldSep;
-              %h = annotation(cstPanel,'textbox','String',obj.parameters{1,p},'Units','pix','Position', [xPos ypos(cnt) 100 objHeight],'Interpreter','Tex');
+              h = text('Parent',tmpAxes,'String',['| ' obj.parameterNames{p} ':'],'VerticalAlignment','middle','Units','normalized','Position',[xPos ypos(cnt)+lineHeight/2],'Interpreter','tex','FontWeight','normal',...
+                  'FontSize',get(cstPanel,'FontSize'),'FontName',get(cstPanel,'FontName'),'FontUnits',get(cstPanel,'FontUnits'),'FontWeight','normal');
+              tmp_pos = get(h,'Extent');
+              xPos = xPos + tmp_pos(3) + fieldSep;
               
               %Check if we have a cell and therefore a parameter list
               if iscell(obj.parameterTypes{p})                  
-                  h = uicontrol(cstPanel,'Style','popupmenu','String',obj.parameterTypes{p}','Value',obj.parameters{p},'TooltipString',obj.parameterNames{p},'Position',[xPos ypos(cnt) paramW*2 objHeight],'UserData',[i,j,p],'Callback',{@editObjParam_Callback,handles});
+                  h = uicontrol(cstPanel,'Style','popupmenu','String',obj.parameterTypes{p}','Value',obj.parameters{p},'TooltipString',obj.parameterNames{p},'Units','normalized','Position',[xPos ypos(cnt) paramW*2 objHeight],'UserData',[i,j,p],'Callback',{@editObjParam_Callback,handles});
               else
-                h = uicontrol(cstPanel,'Style','edit','String',num2str(obj.parameters{p}),'TooltipString',obj.parameterNames{p},'Position',[xPos ypos(cnt) paramW objHeight],'UserData',[i,j,p],'Callback',{@editObjParam_Callback,handles});
+                h = uicontrol(cstPanel,'Style','edit','String',num2str(obj.parameters{p}),'TooltipString',obj.parameterNames{p},'Units','normalized','Position',[xPos ypos(cnt) paramW objHeight],'UserData',[i,j,p],'Callback',{@editObjParam_Callback,handles});
               end
               
-              xPos = xPos + h.Position(3) + fieldSep;
+              tmp_pos = get(h,'Extent');
+              xPos = xPos + tmp_pos(3) + fieldSep;
            end
 
            cnt = cnt +1;
        end
    end   
 end
-xPos = 5;
-hAdd = uicontrol(cstPanel,'Style','pushbutton','String','+','Position',[xPos ypos(cnt) buttonW objHeight],'TooltipString','Add Objective/Constraint','Callback',{@btObjAdd_Callback,handles});
-xPos = xPos + hAdd.Position(3) + fieldSep;
-h = uicontrol(cstPanel,'Style','popupmenu','String',cst(:,2)','Position',[xPos ypos(cnt) nameW objHeight]);
-hAdd.UserData = h;
+xPos = 0.01; %5
+hAdd = uicontrol(cstPanel,'Style','pushbutton','String','+','Units','normalized','Position',[xPos ypos(cnt) buttonW objHeight],'TooltipString','Add Objective/Constraint','Callback',{@btObjAdd_Callback,handles});
+tmp_pos = get(hAdd,'Position');
+xPos = xPos + tmp_pos(3) + fieldSep;
+h = uicontrol(cstPanel,'Style','popupmenu','String',cst(:,2)','Units','normalized','Position',[xPos ypos(cnt) nameW objHeight]);
+set(hAdd,'UserData',h);
 
-%Calculate Scrollbar
+%Calculate Scrollbar / Slider Position
 lastPos = ypos(cnt);
 firstPos = ypos(0);
 tableHeight = abs(firstPos - lastPos);
 
-exceedFac = tableHeight / tableViewHeight;
+exceedFac = tableHeight / tableViewHeight; %How much the current umber of rows exceeds the window height capacity
 if exceedFac > 1
     sliderFac = exceedFac - 1; 
     uicontrol(cstPanel,'Style','slider','Units','normalized','Position',[0.975 0 0.025 1],'Min',0,'Max',ceil(sliderFac)*tableViewHeight,'SliderStep',[lineHeight tableViewHeight] ./ (ceil(sliderFac)*tableViewHeight),'Value',ceil(sliderFac)*tableViewHeight - sliderPos,'Callback',{@cstTableSlider_Callback,handles});
 end
-
-
-
-
-%set(handles.uiTable,'ColumnName',columnname);
-%set(handles.uiTable,'ColumnFormat',columnformat);
-%set(handles.uiTable,'ColumnEditable',[true true true true true true true true true true]);
-%set(handles.uiTable,'Data',data);
-   
+ 
 
 % --- Executes when uipanel3 is resized.
 function uipanel3_SizeChangedFcn(hObject, eventdata, handles)


### PR DESCRIPTION
A hotfix for correct positioning of the optimization view after resizes or similar actions on the matRadGUI. The positions are now relatively computed with the correct coordinates. Also includes some tweaks and compatability changes in the respective code and removes commented code parts.