### PR TITLE
Hotfix for Matlab batch mode crashing in optimization

### DIFF
--- a/optimization/optimizer/matRad_OptimizerIPOPT.m
+++ b/optimization/optimizer/matRad_OptimizerIPOPT.m
@@ -122,18 +122,24 @@ classdef matRad_OptimizerIPOPT < matRad_Optimizer
             fprintf('Press q to terminate the optimization...\n');
             
             % set Callback
-            
+            qCallbackSet = false;
             if ~isdeployed % only if _not_ running as standalone                               
                 switch obj.env
                     case 'MATLAB'
-                        % get handle to Matlab command window
-                        mde         = com.mathworks.mde.desk.MLDesktop.getInstance;
-                        cw          = mde.getClient('Command Window');
-                        xCmdWndView = cw.getComponent(0).getViewport.getComponent(0);
-                        h_cw        = handle(xCmdWndView,'CallbackProperties');
+                        try
+                            % get handle to Matlab command window
+                            mde         = com.mathworks.mde.desk.MLDesktop.getInstance;
+                            cw          = mde.getClient('Command Window');
+                            xCmdWndView = cw.getComponent(0).getViewport.getComponent(0);
+                            h_cw        = handle(xCmdWndView,'CallbackProperties');
                         
-                        % set Key Pressed Callback of Matlab command window
-                        set(h_cw, 'KeyPressedCallback', @(h,event) obj.abortCallbackKey(h,event));
+                            % set Key Pressed Callback of Matlab command window
+                            set(h_cw, 'KeyPressedCallback', @(h,event) obj.abortCallbackKey(h,event));
+                            fprintf('Press q to terminate the optimization...\n');
+                            qCallbackSet = true;
+                        catch
+                            fprintf('Manual optimization termination with q disabled.\n');
+                        end
                 end                
             end
             
@@ -144,7 +150,7 @@ classdef matRad_OptimizerIPOPT < matRad_Optimizer
             [obj.wResult, obj.resultInfo] = ipopt(w0,funcs,ipoptStruct);
             
             % unset Key Pressed Callback of Matlab command window
-            if ~isdeployed && strcmp(obj.env,'MATLAB')
+            if qCallbackSet
                 set(h_cw, 'KeyPressedCallback',' ');
             end
             


### PR DESCRIPTION
Fixes the key pressed callback setup in matRad_OptimizerIPOPT.m that previously lead to a crash when Matlab is run in batch mode. fixes #399 