### PR TITLE
typos in example1_phantom and dicom_export

### DIFF
--- a/dicom/@matRad_DicomExporter/matRad_exportDicomCt.m
+++ b/dicom/@matRad_DicomExporter/matRad_exportDicomCt.m
@@ -67,10 +67,11 @@ ct = obj.ct;
 nSlices = ct.cubeDim(3);
 %Create X Y Z vectors if not present
 if ~any(isfield(ct,{'x','y','z'}))
-    positionOffset = transpose(ct.cubeDim ./ 2);
-    ct.x = ct.resolution.x*[0:ct.cubeDim(1)-1] - positionOffset;
-    ct.y = ct.resolution.y*[0:ct.cubeDim(2)-1] - positionOffset;
-    ct.z = ct.resolution.z*[0:ct.cubeDim(3)-1] - positionOffset;
+    %positionOffset = transpose(ct.cubeDim ./ 2);
+    positionOffset = ct.cubeDim ./ 2;
+    ct.x = ct.resolution.x*[0:ct.cubeDim(2)-1] - positionOffset(2);
+    ct.y = ct.resolution.y*[0:ct.cubeDim(1)-1] - positionOffset(1);
+    ct.z = ct.resolution.z*[0:ct.cubeDim(3)-1] - positionOffset(3);
 end
 
 obj.ct = ct;

--- a/dicom/@matRad_DicomExporter/matRad_exportDicomRTDoses.m
+++ b/dicom/@matRad_DicomExporter/matRad_exportDicomRTDoses.m
@@ -35,10 +35,11 @@ end
 %% CT check
 ct = obj.ct;
 if ~any(isfield(ct,{'x','y','z'}))
-    positionOffset = transpose(ct.cubeDim ./ 2);
-    ct.x = ct.resolution.x*[0:ct.cubeDim(1)-1] - positionOffset;
-    ct.y = ct.resolution.y*[0:ct.cubeDim(2)-1] - positionOffset;
-    ct.z = ct.resolution.z*[0:ct.cubeDim(3)-1] - positionOffset;
+    %positionOffset = transpose(ct.cubeDim ./ 2);
+    positionOffset = ct.cubeDim ./ 2;
+    ct.x = ct.resolution.x*[0:ct.cubeDim(2)-1] - positionOffset(2);
+    ct.y = ct.resolution.y*[0:ct.cubeDim(1)-1] - positionOffset(1);
+    ct.z = ct.resolution.z*[0:ct.cubeDim(3)-1] - positionOffset(3);
 end
 
 %% Meta data

--- a/dicom/@matRad_DicomExporter/matRad_exportDicomRTStruct.m
+++ b/dicom/@matRad_DicomExporter/matRad_exportDicomRTStruct.m
@@ -89,10 +89,11 @@ ct = obj.ct;
 
 %Create X Y Z vectors if not present
 if ~any(isfield(ct,{'x','y','z'}))
-    positionOffset = transpose(ct.cubeDim ./ 2);
-    ct.x = ct.resolution.x*[0:ct.cubeDim(1)-1] - positionOffset;
-    ct.y = ct.resolution.y*[0:ct.cubeDim(2)-1] - positionOffset;
-    ct.z = ct.resolution.z*[0:ct.cubeDim(3)-1] - positionOffset;
+    %positionOffset = transpose(ct.cubeDim ./ 2);
+    positionOffset = ct.cubeDim ./ 2;
+    ct.x = ct.resolution.x*[0:ct.cubeDim(2)-1] - positionOffset(2);
+    ct.y = ct.resolution.y*[0:ct.cubeDim(1)-1] - positionOffset(1);
+    ct.z = ct.resolution.z*[0:ct.cubeDim(3)-1] - positionOffset(3);
 end
 
 
@@ -140,7 +141,7 @@ for i = 1:size(obj.cst,1)
                              ct.y(1) - ct.resolution.y],contours,'UniformOutput',false);
       
     
-    contours = cellfun(@(c,pos) addSlicePos(c,pos),contours,num2cell(contourSlicePos),'UniformOutput',false);
+    contours = cellfun(@(c,pos) addSlicePos(c,pos),contours,num2cell(contourSlicePos)','UniformOutput',false);
     %contours = cellfun(@transpose,contours,'UniformOutput',false);
     
     %Structure Definition

--- a/dicom/@matRad_DicomExporter/matRad_exportDicomRTStruct.m
+++ b/dicom/@matRad_DicomExporter/matRad_exportDicomRTStruct.m
@@ -140,7 +140,7 @@ for i = 1:size(obj.cst,1)
                              ct.y(1) - ct.resolution.y],contours,'UniformOutput',false);
       
     
-    contours = cellfun(@(c,pos) addSlicePos(c,pos),contours,num2cell(contourSlicePos)','UniformOutput',false);    
+    contours = cellfun(@(c,pos) addSlicePos(c,pos),contours,num2cell(contourSlicePos),'UniformOutput',false);
     %contours = cellfun(@transpose,contours,'UniformOutput',false);
     
     %Structure Definition
@@ -153,7 +153,7 @@ for i = 1:size(obj.cst,1)
     
     %Contour Sequence
     if ~isOctave
-        ROIContourSequenceItem.ROIDisplayColor = int32(round(255 * obj.cst{i,5}.visibleColor'));
+        ROIContourSequenceItem.ROIDisplayColor = int32(round(255 * obj.cst{i,5}.visibleColor));
     end
 
     ROIContourSequenceItem.ReferencedROINumber = i;

--- a/examples/matRad_example1_phantom.m
+++ b/examples/matRad_example1_phantom.m
@@ -66,7 +66,7 @@ cst{ixPTV,5}.alphaX      = 0.1000;
 cst{ixPTV,5}.betaX       = 0.0500;
 cst{ixPTV,5}.Priority    = 1;
 cst{ixPTV,5}.Visible     = 1;
-cst{ixOAR,5}.visibleColor = [1 1 1];
+cst{ixPTV,5}.visibleColor = [1 1 1];
 
 % define objective as struct for compatibility with GNU Octave I/O
 cst{ixPTV,6}{1} = struct(DoseObjectives.matRad_SquaredDeviation(800,60));


### PR DESCRIPTION
Hi, 
I am a new user of matRad at the medicine school of UPenn. Thanks for the great work of the whole package. I am trying to understand the package better by going through the unitTest/ and examples/ scripts. There were one typo in examples/matRad_example1_phantom.m and two typos in dicom/@matRad_DicomExporter/matRad_exportDicomRTStruct.m, which caused two errors when running example 1.  Just fixed the typos. 

Thanks,
Weili