### PR TITLE
matRad_siddonRayTracer.m

### DIFF
--- a/matRad_siddonRayTracer.m
+++ b/matRad_siddonRayTracer.m
@@ -196,13 +196,13 @@ alphas_mid = .5*(alphas(1:end-1)+alphas(2:end));
 
 % eq 12
 % Calculate the voxel indices: first convert to physical coords
-i_mm = sourcePoint(1) + alphas_mid*(targetPoint(1) - sourcePoint(1));
-j_mm = sourcePoint(2) + alphas_mid*(targetPoint(2) - sourcePoint(2));
-k_mm = sourcePoint(3) + alphas_mid*(targetPoint(3) - sourcePoint(3));
+i_mm = sourcePoint(1) + alphas_mid*(targetPoint(1) - sourcePoint(1)) - xPlane_1;
+j_mm = sourcePoint(2) + alphas_mid*(targetPoint(2) - sourcePoint(2)) - yPlane_1;
+k_mm = sourcePoint(3) + alphas_mid*(targetPoint(3) - sourcePoint(3)) - zPlane_1;
 % then convert to voxel index
-i = round(i_mm/resolution.x);
-j = round(j_mm/resolution.y);
-k = round(k_mm/resolution.z);
+i = 1 + round(i_mm/resolution.x);
+j = 1 + round(j_mm/resolution.y);
+k = 1 + round(k_mm/resolution.z);
 
 % Handle numerical instabilities at the borders.
 i(i<=0) = 1; j(j<=0) = 1; k(k<=0) = 1;


### PR DESCRIPTION
Follow the original eq.12 of Siddon's paper to calculate voxel indices.

The elapsed time of four beam photon dose matrix calculation reduced about 10s (from ~30s to ~20s) on my macbook ( tic toc functions were applied to the current matRad.m script of the master branch. matRadGUI lines and all lines after dose calculation in matRad.m were comment out. Gantry angles were 0, 90, 180, 270.) Elapsed time of dose calculation in the same four beam setting in proton radiation mode reduced about 3s.

p.s.: The bench test result in matLab shows that my macbook is about five times slower than some reference machine such as Windows10 AMD Ryzen Threadripper 3970x@3.5GHz. The time reduction due to the code change here probably varies on different machines.