### PR TITLE
Restructured Emittance base data storage

### DIFF
--- a/MCsquare/MatRad_MCsquareBaseData.m
+++ b/MCsquare/MatRad_MCsquareBaseData.m
@@ -18,7 +18,11 @@ classdef MatRad_MCsquareBaseData < MatRad_MCemittanceBaseData
     methods (Access = public)
         function obj = MatRad_MCsquareBaseData(machine,stf)
             %Call MatRad_MCemmitanceBaseData constructor
-            obj = obj@MatRad_MCemittanceBaseData(machine,stf);             
+            if nargin < 2
+                stf = [];
+            end
+            
+            obj = obj@MatRad_MCemittanceBaseData(machine, stf);
         end
                 
         function obj = writeMCsquareData(obj,filepath)
@@ -35,7 +39,7 @@ classdef MatRad_MCsquareBaseData < MatRad_MCemittanceBaseData
             end
             
             %remove field not needed for MCsquare base data
-            selectedData = rmfield(selectedData, 'FWHMatIso');
+%             selectedData = rmfield(selectedData, 'FWHMatIso');
             
             %write MCsqaure data base file
             try
@@ -77,9 +81,11 @@ classdef MatRad_MCsquareBaseData < MatRad_MCemittanceBaseData
                 end
                 fprintf(fileID, '\n');
                 
+                indices = obj.selectedFocus(obj.energyIndex);
                 for k = 1:size(selectedData,2)
                     for m = 1:numel(fn)
-                        fprintf(fileID, '%g', selectedData(k).(fn{m}));
+                        tmp = selectedData(k).(fn{m});
+                        fprintf(fileID, '%g ', tmp(indices(k)));
                         fprintf(fileID, '\t');
                     end
                     fprintf(fileID, '\n');

--- a/MatRad_MCemittanceBaseData.m
+++ b/MatRad_MCemittanceBaseData.m
@@ -114,24 +114,23 @@ classdef MatRad_MCemittanceBaseData
                         energyData = obj.fitPhaseSpaceForEnergy(i);
                 end
                     
-                if isfield(machine.data(i).initFocus,'spotsize') && isfield(machine.data(i).initFocus,'divergence') ...
-                        && isfield(machine.data(i).initFocus,'correlation') && isfield(machine.data(i).initFocus,'weight') ...
+                if isfield(machine.data(i).initFocus,'Emittance') 
                     data = [];
                     opticsData.ProtonsMU        = ones(1,4) * 1e6;   
-                    opticsData.Weight1          = machine.data(i).initFocus.weight.fist(:);
-                    opticsData.SpotSize1x       = machine.data(i).initFocus.spotsize.x1(:);
-                    opticsData.Divergence1x     = machine.data(i).initFocus.divergence.x1(:);
-                    opticsData.Correlation1x    = machine.data(i).initFocus.correlation.x1(:); 
-                    opticsData.SpotSize1y       = machine.data(i).initFocus.spotsize.y1(:);
-                    opticsData.Divergence1y     = machine.data(i).initFocus.divergence.y1(:);
-                    opticsData.Correlation1y    = machine.data(i).initFocus.correlation.y1(:); 
-                    opticsData.Weight2          = machine.data(i).initFocus.weight.second(:);
-                    opticsData.SpotSize2x       = machine.data(i).initFocus.spotsize.x2(:);
-                    opticsData.Divergence2x     = machine.data(i).initFocus.divergence.x2(:);
-                    opticsData.Correlation2x    = machine.data(i).initFocus.correlation.x2(:);
-                    opticsData.SpotSize2y       = machine.data(i).initFocus.spotsize.y2(:);
-                    opticsData.Divergence2y     = machine.data(i).initFocus.divergence.y2(:);
-                    opticsData.Correlation2y    = machine.data(i).initFocus.spotsize.y2(:);
+                    opticsData.Weight1          = machine.data(i).initFocus.Emittance.weight.first(:);
+                    opticsData.SpotSize1x       = machine.data(i).initFocus.Emittance.spotsize.x1(:);
+                    opticsData.Divergence1x     = machine.data(i).initFocus.Emittance.divergence.x1(:);
+                    opticsData.Correlation1x    = machine.data(i).initFocus.Emittance.correlation.x1(:); 
+                    opticsData.SpotSize1y       = machine.data(i).initFocus.Emittance.spotsize.y1(:);
+                    opticsData.Divergence1y     = machine.data(i).initFocus.Emittance.divergence.y1(:);
+                    opticsData.Correlation1y    = machine.data(i).initFocus.Emittance.correlation.y1(:); 
+                    opticsData.Weight2          = machine.data(i).initFocus.Emittance.weight.second(:);
+                    opticsData.SpotSize2x       = machine.data(i).initFocus.Emittance.spotsize.x2(:);
+                    opticsData.Divergence2x     = machine.data(i).initFocus.Emittance.divergence.x2(:);
+                    opticsData.Correlation2x    = machine.data(i).initFocus.Emittance.correlation.x2(:);
+                    opticsData.SpotSize2y       = machine.data(i).initFocus.Emittance.spotsize.y2(:);
+                    opticsData.Divergence2y     = machine.data(i).initFocus.Emittance.divergence.y2(:);
+                    opticsData.Correlation2y    = machine.data(i).initFocus.Emittance.spotsize.y2(:);
                     
                     tmp = energyData;
                     f = fieldnames(opticsData);
@@ -331,22 +330,24 @@ classdef MatRad_MCemittanceBaseData
             count = 1;
             for i = obj.energyIndex'
                 
-                obj.machine.data(i).initFocus.spotsize.x1 = [obj.monteCarloData(:,count).SpotSize1x];
-                obj.machine.data(i).initFocus.spotsize.y1 = [obj.monteCarloData(:,count).SpotSize1y];
-                obj.machine.data(i).initFocus.spotsize.x2 = [obj.monteCarloData(:,count).SpotSize2x];
-                obj.machine.data(i).initFocus.spotsize.y2 = [obj.monteCarloData(:,count).SpotSize2y];
-                obj.machine.data(i).initFocus.divergence.x1 = [obj.monteCarloData(:,count).Divergence1x];
-                obj.machine.data(i).initFocus.divergence.y1 = [obj.monteCarloData(:,count).Divergence1y];
-                obj.machine.data(i).initFocus.divergence.x2 = [obj.monteCarloData(:,count).Divergence2x];
-                obj.machine.data(i).initFocus.divergence.y2 = [obj.monteCarloData(:,count).Divergence2y];
-                obj.machine.data(i).initFocus.correlation.x1 = [obj.monteCarloData(:,count).Correlation1x];
-                obj.machine.data(i).initFocus.correlation.y1 = [obj.monteCarloData(:,count).Correlation1y];
-                obj.machine.data(i).initFocus.correlation.x2 = [obj.monteCarloData(:,count).Correlation2x];
-                obj.machine.data(i).initFocus.correlation.y2 = [obj.monteCarloData(:,count).Correlation2y];
-                obj.machine.data(i).initFocus.weight.fist   =  [obj.monteCarloData(:,count).Weight1];
-                obj.machine.data(i).initFocus.weight.second =  [obj.monteCarloData(:,count).Weight2];
+                obj.machine.data(i).initFocus.Emittance.spotsize.x1 = [obj.monteCarloData(:,count).SpotSize1x];
+                obj.machine.data(i).initFocus.Emittance.spotsize.y1 = [obj.monteCarloData(:,count).SpotSize1y];
+                obj.machine.data(i).initFocus.Emittance.spotsize.x2 = [obj.monteCarloData(:,count).SpotSize2x];
+                obj.machine.data(i).initFocus.Emittance.spotsize.y2 = [obj.monteCarloData(:,count).SpotSize2y];
+                obj.machine.data(i).initFocus.Emittance.divergence.x1 = [obj.monteCarloData(:,count).Divergence1x];
+                obj.machine.data(i).initFocus.Emittance.divergence.y1 = [obj.monteCarloData(:,count).Divergence1y];
+                obj.machine.data(i).initFocus.Emittance.divergence.x2 = [obj.monteCarloData(:,count).Divergence2x];
+                obj.machine.data(i).initFocus.Emittance.divergence.y2 = [obj.monteCarloData(:,count).Divergence2y];
+                obj.machine.data(i).initFocus.Emittance.correlation.x1 = [obj.monteCarloData(:,count).Correlation1x];
+                obj.machine.data(i).initFocus.Emittance.correlation.y1 = [obj.monteCarloData(:,count).Correlation1y];
+                obj.machine.data(i).initFocus.Emittance.correlation.x2 = [obj.monteCarloData(:,count).Correlation2x];
+                obj.machine.data(i).initFocus.Emittance.correlation.y2 = [obj.monteCarloData(:,count).Correlation2y];
+                obj.machine.data(i).initFocus.Emittance.weight.first   =  [obj.monteCarloData(:,count).Weight1];
+                obj.machine.data(i).initFocus.Emittance.weight.second =  [obj.monteCarloData(:,count).Weight2];
                 obj.machine.data(i).energySpectrum.mean   = [obj.monteCarloData(:,count).MeanEnergy];
                 obj.machine.data(i).energySpectrum.spread = [obj.monteCarloData(:,count).EnergySpread];
+                obj.machine.data(i).energySpectrum.type  = 'Gaussian';
+                obj.machine.data(i).initFocus.Emittance.type  = 'BiGaussian';
 
                 count = count + 1;
             end

--- a/matRad_calcParticleDoseMCsquare.m
+++ b/matRad_calcParticleDoseMCsquare.m
@@ -189,12 +189,12 @@ MCsquareConfig = MatRad_MCsquareConfig;
 bdFile = [machine.meta.machine '.txt'];
 
 % bdFile = 'BDL_matRad.txt'; %use for baseData fit 
-MCsquareBDL = MatRad_MCsquareBaseData(machine,stf);
+MCsquareBDL = MatRad_MCsquareBaseData(machine, stf);
 %matRad_createMCsquareBaseDataFile(bdFile,machine,1);
 % MCsquareBDL = MCsquareBDL.saveMatradMachine('test');
 MCsquareBDL = MCsquareBDL.writeMCsquareData([MCsquareFolder filesep 'BDL' filesep bdFile]);
 %movefile(bdFile,[MCsquareFolder filesep 'BDL/' bdFile]);
-% MCsquareBDL = MCsquareBDL.saveMatradMachine('testMachine');
+% MCsquareBDL = MCsquareBDL.saveMatradMachine('savedMatRadMachine');
 
 MCsquareConfig.BDL_Machine_Parameter_File = ['BDL/' bdFile];
 MCsquareConfig.BDL_Plan_File = 'currBixels.txt';

--- a/matRad_calcParticleDoseMCsquare.m
+++ b/matRad_calcParticleDoseMCsquare.m
@@ -189,12 +189,14 @@ MCsquareConfig = MatRad_MCsquareConfig;
 bdFile = [machine.meta.machine '.txt'];
 
 % bdFile = 'BDL_matRad.txt'; %use for baseData fit 
-MCsquareBDL = MatRad_MCsquareBaseData(machine, stf);
+
+% Argument stf is optional, if given, calculation only for energies given in stf
+% MCsquareBDL = MatRad_MCsquareBaseData(machine, stf);
+MCsquareBDL = MatRad_MCsquareBaseData(machine);
+
 %matRad_createMCsquareBaseDataFile(bdFile,machine,1);
-% MCsquareBDL = MCsquareBDL.saveMatradMachine('test');
 MCsquareBDL = MCsquareBDL.writeMCsquareData([MCsquareFolder filesep 'BDL' filesep bdFile]);
-%movefile(bdFile,[MCsquareFolder filesep 'BDL/' bdFile]);
-% MCsquareBDL = MCsquareBDL.saveMatradMachine('savedMatRadMachine');
+MCsquareBDL = MCsquareBDL.saveMatradMachine('savedMatRadMachine');
 
 MCsquareConfig.BDL_Machine_Parameter_File = ['BDL/' bdFile];
 MCsquareConfig.BDL_Plan_File = 'currBixels.txt';


### PR DESCRIPTION
I restructured the MCEmittanceBaseData class, such that it now stores the generated emittance base data, which can be used in a MCsquare or TOPAS Monte Carlo simulation, in a new fields in the matRad base data file. 
If one selects to create a new base data file, whichs should include the generated parametrisation, for every energy in the base data file, a field energySpectrum is now created, which contains the mean energy of the respective proton source and its energy spread. 
In addition, every initFocus field is expanded by the found beam optics data for every available focus index.
I also fixed smaller bugs related to the whole base data generation process in MCsquareBaseData.
