### PR TITLE
TOPAS: added error message for insufficient number of histories

### DIFF
--- a/topas/MatRad_TopasConfig.m
+++ b/topas/MatRad_TopasConfig.m
@@ -399,6 +399,10 @@ classdef MatRad_TopasConfig < handle
                 
                 historyCount(beamIx) = uint32(obj.fracHistories * nBeamParticlesTotal(beamIx) / obj.numOfRuns);
                 
+                if historyCount < cutNumOfBixel || cutNumOfBixel == 0
+                    obj.matRad_cfg.dispError('Insufficient number of histories!')
+                end
+                
                 while sum([dataTOPAS.current]) ~= historyCount(beamIx)
                     % Randomly pick an index with the weigth given by the current
                     idx = 1:length(dataTOPAS);


### PR DESCRIPTION
Added an error message for insufficient number of histories, where the code could get stuck in a while loop.