### PR TITLE
Fix issue with effective lateral cutoff for large photon fields

### DIFF
--- a/MatRad_Config.m
+++ b/MatRad_Config.m
@@ -152,6 +152,7 @@ classdef MatRad_Config < handle
             obj.propDoseCalc.defaultResolution = struct('x',3,'y',3,'z',3); %[mm]
             obj.propDoseCalc.defaultLateralCutOff = 0.995; %[rel.]
             obj.propDoseCalc.defaultGeometricCutOff = 50; %[mm]
+            obj.propDoseCalc.defaultKernelCutOff = Inf; %[mm]
             obj.propDoseCalc.defaultSsdDensityThreshold = 0.05; %[rel.]
             obj.propDoseCalc.defaultUseGivenEqDensityCube = false; %Use the given density cube ct.cube and omit conversion from cubeHU.
             obj.propDoseCalc.defaultIgnoreOutsideDensities = true; %Ignore densities outside of cst contours
@@ -180,6 +181,7 @@ classdef MatRad_Config < handle
             obj.propDoseCalc.defaultResolution = struct('x',5,'y',6,'z',7); %[mm]
             obj.propDoseCalc.defaultGeometricCutOff = 20;
             obj.propDoseCalc.defaultLateralCutOff = 0.8;
+            obj.propDoseCalc.defaultKernelCutOff = 20; %[mm]
             obj.propDoseCalc.defaultSsdDensityThreshold = 0.05;
             obj.propDoseCalc.defaultUseGivenEqDensityCube = false; %Use the given density cube ct.cube and omit conversion from cubeHU.
             obj.propDoseCalc.defaultIgnoreOutsideDensities = true;

--- a/matRad_calcPhotonDose.m
+++ b/matRad_calcPhotonDose.m
@@ -124,7 +124,7 @@ kernelLimit = ceil(lateralCutoff/intConvResolution);
                             intConvResolution: ...
                             (kernelLimit-1)*intConvResolution);
 
-% precalculate convoluted kernel size and distances
+% precalculate convolved kernel size and distances
 kernelConvLimit = fieldLimit + gaussLimit + kernelLimit;
 [convMx_X, convMx_Z] = meshgrid(-kernelConvLimit*intConvResolution: ...
                                 intConvResolution: ...
@@ -134,7 +134,7 @@ kernelConvSize = 2*kernelConvLimit;
 
 % define an effective lateral cutoff where dose will be calculated. note
 % that storage within the influence matrix may be subject to sampling
-effectiveLateralCutoff = lateralCutoff + fieldWidth/2;
+effectiveLateralCutoff = lateralCutoff + fieldWidth/sqrt(2);
 
 counter = 0;
 matRad_cfg.dispInfo('matRad: Photon dose calculation...\n');
@@ -206,7 +206,7 @@ for i = 1:dij.numOfBeams % loop over all beams
             % apply the primary fluence to the field
             Fx = F .* Psi;
             
-            % convolute with the gaussian
+            % convolve with the gaussian
             Fx = real( ifft2(fft2(Fx,gaussConvSize,gaussConvSize).* fft2(gaussFilter,gaussConvSize,gaussConvSize)) );
 
             % 2D convolution of Fluence and Kernels in fourier domain


### PR DESCRIPTION
**Issue:**
The photon dose calculation did incorrectly cut the field for large field sizes (compare #490)
**Cause:**
Ray-tracing and geometric distance calculation interpret the lateral cutoff as radial distance, but the photon dose calculation computes it for square fields based on the side length. For small fields, the lateral CutOff is relatively too large to show a visible effect, but larger field then get "cut" at the edges by the circle. 
**Fix:** 
Set the effective lateral cut off for squared fields based on their diagonal.

Fixes #490 
