### PR TITLE
Migrate from TravisCI to GitHub actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,19 @@ jobs:
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v1        
       # Runs test command
-      - name: Run Testscript
+      - name: Run Tests
         uses: matlab-actions/run-command@v1
         with:
           command: cd unitTest; matRad_runTests
+  test-octave:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2 # Checks-out repository under $GITHUB_WORKSPACE
+      - name: Install OCTAVE
+        run: sudo apt-get install -y gdb gfortran fonts-freefont-otf gnuplot-x11 libgdcm-dev octave liboctave-dev
+      - name: Prepare Test Environment
+        run: |
+          sudo chmod +x .travis/before_install_linux.sh
+          sudo .travis/before_install_linux.sh
+      - name: Run Tests
+        run: .travis/runtests.sh octave-cli

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,4 +29,6 @@ jobs:
           sudo chmod +x .travis/before_install_linux.sh
           sudo .travis/before_install_linux.sh
       - name: Run Tests
-        run: .travis/runtests.sh octave-cli
+        uses: GabrielBB/xvfb-action@v1 #For Headless tests
+        with:
+          run: .travis/runtests.sh octave-cli

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,32 +1,20 @@
 # This is a basic workflow to help you get started with Actions
 name: Testing
-
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
-  push:
+  push: #Triggers the workflow on push or pull request events
+  workflow_dispatch: # Allows manual trigger
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   test-matlab:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v2 # Checks-out repository under $GITHUB_WORKSPACE
       # Install MATLAB
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v0
-        
-      # Runs a set of commands using the runners shell
+        uses: matlab-actions/setup-matlab@v1        
+      # Runs test command
       - name: Run Testscript
-        uses: matlab-actions/run-command@v0
+        uses: matlab-actions/run-command@v1
         with:
           command: cd unitTest; matRad_runTests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,9 @@
 # This is a basic workflow to help you get started with Actions
 name: Testing
 # Controls when the action will run. 
-on:
-  push: #Triggers the workflow on push or pull request events
-  workflow_dispatch: # Allows manual trigger
-
+on: [push, pull_request, workflow_dispatch]  
 jobs:
-  test-matlab:
+  test-matlab: #Matlab test Job
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # Checks-out repository under $GITHUB_WORKSPACE
@@ -18,8 +15,8 @@ jobs:
         uses: matlab-actions/run-command@v1
         with:
           command: cd unitTest; matRad_runTests
-  test-octave:
-    runs-on: ubuntu-20.04
+  test-octave: #Octave test Job
+    runs-on: ubuntu-20.04 # We use Ubuntu-20.04 because it has Octave 5.2
     steps:
       - uses: actions/checkout@v2 # Checks-out repository under $GITHUB_WORKSPACE
       - name: Install OCTAVE
@@ -32,3 +29,10 @@ jobs:
         uses: GabrielBB/xvfb-action@v1 #For Headless tests
         with:
           run: .travis/runtests.sh octave-cli
+      - name: Upload Logs if failure
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: Test Log
+          path: runtests.log
+            

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+# This is a basic workflow to help you get started with Actions
+name: Testing
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  test-matlab:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Install MATLAB
+      - name: Install MATLAB
+        uses: matlab-actions/setup-matlab@v0
+        
+      # Runs a set of commands using the runners shell
+      - name: Run Testscript
+        uses: matlab-actions/run-command@v0
+        with:
+          command: cd unitTest; matRad_runTests


### PR DESCRIPTION
This PR solely creates a GitHub Action that migrates our automated testing from TravisCI to GitHub Actions.
Two test jobs are run on an Ubuntu 20.04 VM, once with Matlab and once with Octave 5.2.

Reasons for the Migration:
- TravisCI has switched to a much more restrictive business model for open-source projects which will not work with matRad
- GitHub Actions are very flexible, and easy to configure
- We have one external service less where we need accounts and so on

This PR will not require a review, I will merge it as soon as the tests run through.