### PR TITLE
Fix RTDose import when no RTPlan is imported

### DIFF
--- a/dicom/matRad_importDicom.m
+++ b/dicom/matRad_importDicom.m
@@ -130,10 +130,8 @@ if isfield(files,'rtdose')
     if ~(cellfun(@isempty,files.rtdose(1,1:2))) 
         fprintf('loading Dose files \n', structures(i).structName);
         % parse plan in order to scale dose cubes to a fraction based dose
-        if exist('pln','var')
-            if isfield(pln,'numOfFractions')
-                resultGUI = matRad_importDicomRTDose(ct, files.rtdose, pln);
-            end
+        if exist('pln','var') && ~isempty(pln) && isfield(pln,'numOfFractions')
+            resultGUI = matRad_importDicomRTDose(ct, files.rtdose, pln);
         else
             resultGUI = matRad_importDicomRTDose(ct, files.rtdose);
         end


### PR DESCRIPTION
This is a hotfix directly on the master branch. It fixes a bug in the DICOM import (brought up in #558) that, when wanting to import RTDose without an RTPlan, skipped the dose import such that the dose was never imported.

The fix is fairly simple, so I will directly merge this as soon as the checks pass.