### PR TITLE
Fix error when constraints are applied to volumes which have 0 or 1 voxel.

### DIFF
--- a/matRad_resizeCstToGrid.m
+++ b/matRad_resizeCstToGrid.m
@@ -40,5 +40,9 @@ for i = 1:size(cst,1)
       cst{i,4}{j}          = find(matRad_interp3(vXgridOld,vYgridOld,vZgridOld, ...
                                                  tmpCube, ...
                                                  vXgridNew,vYgridNew',vZgridNew,'nearest'));
+      if isempty(cst{i,4}{j})
+          matRad_cfg = MatRad_Config.instance();
+          matRad_cfg.dispWarning('Resizing the cst to the dose grid created an empty structure %s in scenario %d (cst{%d,4}{%d})!',cst{i,2},j,i,j);
+      end
    end
 end

--- a/optimization/@matRad_OptimizationProblem/matRad_getConstraintBounds.m
+++ b/optimization/@matRad_OptimizationProblem/matRad_getConstraintBounds.m
@@ -39,7 +39,7 @@ cu = [];
 for  i = 1:size(cst,1)
 
     % Only take OAR or target VOI.
-    if ~isempty(cst{i,4}) && ( isequal(cst{i,3},'OAR') || isequal(cst{i,3},'TARGET') )
+    if ~any(cellfun(@isempty,cst{i,4})) && ( isequal(cst{i,3},'OAR') || isequal(cst{i,3},'TARGET') )
 
         % loop over the number of constraints for the current VOI
         for j = 1:numel(cst{i,6})

--- a/optimization/@matRad_OptimizationProblem/matRad_getJacobianStructure.m
+++ b/optimization/@matRad_OptimizationProblem/matRad_getJacobianStructure.m
@@ -36,7 +36,7 @@ jacobStruct = sparse([]);
  % compute objective function for every VOI.	
 for i = 1:size(cst,1)	
      % Only take OAR or target VOI.	
-    if ~isempty(cst{i,4}{1}) && ( isequal(cst{i,3},'OAR') || isequal(cst{i,3},'TARGET') )	
+    if ~any(cellfun(@isempty,cst{i,4})) && ( isequal(cst{i,3},'OAR') || isequal(cst{i,3},'TARGET') )	
          % loop over the number of constraints for the current VOI	
         for j = 1:numel(cst{i,6})	
             	
@@ -48,7 +48,7 @@ for i = 1:size(cst,1)
                 % get the jacobian structure depending on dose	
                 jacobDoseStruct = obj.getDoseConstraintJacobianStructure(numel(cst{i,4}{1}));	
                 nRows = size(jacobDoseStruct,2);	
-                jacobStruct = [jacobStruct; repmat(spones(mean(dij.physicalDose{1}(cst{i,4}{1},:))),nRows,1)];	
+                jacobStruct = [jacobStruct; repmat(spones(mean(dij.physicalDose{1}(cst{i,4}{1},:),1)),nRows,1)];	
                  
              end	
          end	


### PR DESCRIPTION
Fixes #601 

Decided to directly merge in the master branch as it is a quite straightforward fix. Thanks to @zperko for reporting and proposing the fix.