### PR TITLE
Dev class GUI .mat patient load bug

### DIFF
--- a/gui/matRad_MainGUI.m
+++ b/gui/matRad_MainGUI.m
@@ -340,6 +340,7 @@ classdef matRad_MainGUI < handle
            this.PlanWidget.update(evt);
            this.WorkflowWidget.update(evt);
            this.OptimizationWidget.update(evt);
+           this.ViewingWidget.lockUpdate = 0;
            this.ViewingWidget.update(evt);
            %this.ViewerOptionsWidget.update();
            %this.VisualizationWidget.update();

--- a/matRad.m
+++ b/matRad.m
@@ -18,7 +18,7 @@ matRad_rc
 % load patient data, i.e. ct, voi, cst
 
 %load HEAD_AND_NECK
-% load TG119.mat
+load TG119.mat
 %load PROSTATE.mat
 %load LIVER.mat
 %load BOXPHANTOM.mat


### PR DESCRIPTION
to recreate the bug, on empty corkspace load matRadGUI and load .mat patient case.
This would result in an empty viewing widget 