### PR TITLE
IsoCenterShift BugFix

### DIFF
--- a/matRad_calcParticleDoseMCtopas.m
+++ b/matRad_calcParticleDoseMCtopas.m
@@ -220,6 +220,11 @@ for shiftScen = 1:pln.multScen.totNumShiftScen
     
     % revert back to original directory
     cd(currDir);
+
+    % manipulate isocenter back
+    for k = 1:length(stf)
+        stf(k).isoCenter = stf(k).isoCenter - pln.multScen.isoShift(ixShiftScen,:);
+    end
     
 end
 
@@ -234,8 +239,4 @@ else
     dij = struct([]);
 end
 
-% manipulate isocenter back
-for k = 1:length(stf)
-    stf(k).isoCenter = stf(k).isoCenter - pln.multScen.isoShift(ixShiftScen,:);
-end
 end


### PR DESCRIPTION
The IsoCenter was shifted back after all simulations were performed, this leads to an accumulation of the isocenter shift. It needs to be shifted back after each simulation