### PR TITLE
bug fix for use of nominal ct scenarios used for robustness "none"

### DIFF
--- a/matRad_fluenceOptimization.m
+++ b/matRad_fluenceOptimization.m
@@ -201,6 +201,9 @@ end
 
 linIxDIJ = find(~cellfun(@isempty,dij.physicalDose(scen4D,:,:)))';
 
+%Only select the indexes of the nominal ct Scenarios
+linIxDIJ_nominalCT = find(~cellfun(@isempty,dij.physicalDose(scen4D,1,1)))';
+
 FLAG_CALC_PROB = false;
 FLAG_ROB_OPT   = false;
 
@@ -247,7 +250,8 @@ end
 
 %Give scenarios used for optimization
 backProjection.scenarios    = ixForOpt;
-backProjection.scenarioProb = pln.multScen.scenProb;
+backProjection.scenarioProb = repmat(pln.multScen.scenProb, pln.multScen.numOfCtScen,1);
+backProjection.nominalCtScenarios = linIxDIJ_nominalCT;
 
 optiProb = matRad_OptimizationProblem(backProjection);
 optiProb.quantityOpt = pln.bioParam.quantityOpt;

--- a/optimization/@matRad_OptimizationProblem/matRad_objectiveFunction.m
+++ b/optimization/@matRad_OptimizationProblem/matRad_objectiveFunction.m
@@ -41,6 +41,7 @@ d = optiProb.BP.GetResult();
 % get the used scenarios
 useScen  = optiProb.BP.scenarios;
 scenProb = optiProb.BP.scenarioProb;
+useNominalCtScen = optiProb.BP.nominalCtScenarios;
 
 % retrieve matching 4D scenarios
 fullScen = cell(ndims(d),1);
@@ -75,8 +76,8 @@ for  i = 1:size(cst,1)
                 
                 switch robustness
                     case 'none' % if conventional opt: just sum objectives of nominal dose
-                        for ixScen = useScen
-                            d_i = d{ixScen}(cst{i,4}{useScen(1)});
+                        for ixScen = useNominalCtScen
+                            d_i = d{ixScen}(cst{i,4}{useScen(ixScen)});
                             f = f + objective.penalty * objective.computeDoseObjectiveFunction(d_i);
                         end
 

--- a/optimization/@matRad_OptimizationProblem/matRad_objectiveGradient.m
+++ b/optimization/@matRad_OptimizationProblem/matRad_objectiveGradient.m
@@ -46,6 +46,7 @@ d = optiProb.BP.GetResult();
 % get the used scenarios
 useScen  = optiProb.BP.scenarios;
 scenProb = optiProb.BP.scenarioProb;
+useNominalCtScen = optiProb.BP.nominalCtScenarios;
 
 % retrieve matching 4D scenarios
 fullScen      = cell(ndims(d),1);
@@ -84,7 +85,7 @@ for  i = 1:size(cst,1)
                 
                 switch robustness
                     case 'none' % if conventional opt: just sum objectiveectives of nominal dose
-                        for s = 1:numel(useScen)
+                        for s = useNominalCtScen
                             ixScen = useScen(s);
                             ixContour = contourScen(s);
                             d_i = d{ixScen}(cst{i,4}{ixContour});

--- a/optimization/projections/matRad_BackProjection.m
+++ b/optimization/projections/matRad_BackProjection.m
@@ -27,9 +27,10 @@ classdef matRad_BackProjection < handle
     end
     
     properties 
-        dij                 %reference to matRad dij struct (to enable local changes)
-        scenarios    = 1    %Scenario indices to evaluate (used for 4D & robust/stochastic optimization)
-        scenarioProb = 1    %Probability associated with scenario (for stochastic optimization)
+        dij                     %reference to matRad dij struct (to enable local changes)
+        scenarios    = 1        %Scenario indices to evaluate (used for 4D & robust/stochastic optimization)
+        scenarioProb = 1        %Probability associated with scenario (for stochastic optimization)
+        nominalCtScenarios = 1; %nominal ct scenario (no shift, no range error) indices to evaluate (used for 4D & robust/stochastic optimization, when at least one cst structure does not have robustness)
     end
 
     


### PR DESCRIPTION
Results are only affected when multiple cst structures have different robustness specifications, at least one of wich is "none".
In this case multiple scenarios will be present and only the selecten nominal ct scenarios need to be taken into account for "none" robustness.

Minor changes in:

- `matRad_objectiveFunction` and `matRad_objectiveGradient` to avoid looping over all scenarios
- `matRad_fluenceOptimization` to select the nominal ct scenarios (if not all 4Dscen are used)
- `matRad_BackProjection` to store the indexes of nominal ctScen
