### PR TITLE
Loading plans from the ETHOS device enabled

### DIFF
--- a/dicom/matRad_loadHLUT.m
+++ b/dicom/matRad_loadHLUT.m
@@ -43,8 +43,11 @@ try
     particle     = pln.radiationMode;
     manufacturer = ct.dicomInfo.Manufacturer;
     model        = ct.dicomInfo.ManufacturerModelName;
-    convKernel   = ct.dicomInfo.ConvolutionKernel;
-    
+    if isfield(ct.dicomInfo,'ConvolutionKernel')
+        convKernel = ct.dicomInfo.ConvolutionKernel;
+    else
+        convKernel = '0';
+    end
     hlutFileName = strcat(manufacturer, '-', model, '-ConvolutionKernel-',...
         convKernel, '_', particle, '.hlut');
     

--- a/matRad_calcDoseDirectMC.m
+++ b/matRad_calcDoseDirectMC.m
@@ -82,25 +82,26 @@ end
 % dose calculation
 if strcmp(pln.radiationMode,'protons')
     dij = matRad_calcParticleDoseMC(ct,stf,pln,cst,nHistories,calcDoseDirect);
+    % hack dij struct
+    dij.numOfBeams = 1;
+    dij.beamNum = 1;
+    % calculate cubes; use uniform weights here, weighting with actual fluence 
+    % already performed in dij construction 
+    resultGUI = matRad_calcCubes(sum(w),dij);
+    % remember original fluence weights
+    resultGUI.w = w; 
 elseif strcmp(pln.radiationMode,'photons')
     nCasePerBixel = nHistories;
     visBool = false;
     dij = matRad_calcPhotonDoseMC(ct,stf,pln,cst,nCasePerBixel,visBool);
+    resultGUI = matRad_calcCubes(w,dij);
 else
     matRad_cfg.dispError('Forward MC only implemented for protons and photons.');
 end
 
-% hack dij struct
-%dij.numOfBeams = 1;
-%dij.beamNum = 1;
 
-% calculate cubes; use uniform weights here, weighting with actual fluence 
-% already performed in dij construction 
-%resultGUI    = matRad_calcCubes(sum(w),dij);
-resultGUI    = matRad_calcCubes(w,dij);
 
-% remember original fluence weights
-%resultGUI.w  = w; 
+
 
 
 

--- a/matRad_calcDoseDirectMC.m
+++ b/matRad_calcDoseDirectMC.m
@@ -81,21 +81,26 @@ end
 
 % dose calculation
 if strcmp(pln.radiationMode,'protons')
-  dij = matRad_calcParticleDoseMC(ct,stf,pln,cst,nHistories,calcDoseDirect);
+    dij = matRad_calcParticleDoseMC(ct,stf,pln,cst,nHistories,calcDoseDirect);
+elseif strcmp(pln.radiationMode,'photons')
+    nCasePerBixel = nHistories;
+    visBool = false;
+    dij = matRad_calcPhotonDoseMC(ct,stf,pln,cst,nCasePerBixel,visBool);
 else
-    matRad_cfg.dispError('Forward MC only implemented for protons.');
+    matRad_cfg.dispError('Forward MC only implemented for protons and photons.');
 end
 
 % hack dij struct
-dij.numOfBeams = 1;
-dij.beamNum = 1;
+%dij.numOfBeams = 1;
+%dij.beamNum = 1;
 
 % calculate cubes; use uniform weights here, weighting with actual fluence 
 % already performed in dij construction 
-resultGUI    = matRad_calcCubes(sum(w),dij);
+%resultGUI    = matRad_calcCubes(sum(w),dij);
+resultGUI    = matRad_calcCubes(w,dij);
 
 % remember original fluence weights
-resultGUI.w  = w; 
+%resultGUI.w  = w; 
 
 
 


### PR DESCRIPTION
Contains changes to matRad_importFieldShapes.m that enable us to load RTPlan files coming from the Varian ETHOS device. *There is an additional older change to matRad_calcDoseDirectMC.m which accidentally ended up in this commit. 