### PR TITLE
Import DICOM with HFP/FFP orientation Update

### DIFF
--- a/dicom/matRad_convRtssContours2Indices.m
+++ b/dicom/matRad_convRtssContours2Indices.m
@@ -67,33 +67,6 @@ for i = 1:size(structure.item,2)
     end
     
 end
-% The x- & y-direction in lps-coordinates are specified in:
-% ImageOrientationPatient
-
-xDir = ct.dicomInfo.ImageOrientationPatient(1:3); % lps: [1;0;0]
-yDir = ct.dicomInfo.ImageOrientationPatient(4:6); % lps: [0;1;0]
-nonStandardDirection = false;
-
-if xDir(1) == 1 && xDir(2) == 0 && xDir(3) == 0
-%     matRad_cfg.dispInfo('x-direction OK\n')
-elseif xDir(1) == -1 && xDir(2) == 0 && xDir(3) == 0
-    voiCube = flip(voiCube,1);
-else
-    nonStandardDirection = true;
-end
-    
-if yDir(1) == 0 && yDir(2) == 1 && yDir(3) == 0
-%     matRad_cfg.dispInfo('y-direction OK\n')
-elseif yDir(1) == 0 && yDir(2) == -1 && yDir(3) == 0
-    voiCube = flip(voiCube,2);
-else
-    nonStandardDirection = true;
-end
-
-if nonStandardDirection
-    matRad_cfg.dispWarning(['Non-standard patient orientation.\n'...
-        'CT might not fit to contoured structures\n'])
-end
 
 indices = find(voiCube(:));
 

--- a/dicom/matRad_interpDicomCtCube.m
+++ b/dicom/matRad_interpDicomCtCube.m
@@ -33,12 +33,23 @@ function interpCt = matRad_interpDicomCtCube(origCt, origCtInfo, resolution, gri
 
 coordsOfFirstPixel = [origCtInfo.ImagePositionPatient];
 
+xDir = origCtInfo(1).ImageOrientationPatient(1:3); % lps: [1;0;0]
+yDir = origCtInfo(1).ImageOrientationPatient(4:6); % lps: [0;1;0]
+
 % set up original grid vectors
 x = coordsOfFirstPixel(1,1) + origCtInfo(1).ImageOrientationPatient(1) * ...
                               origCtInfo(1).PixelSpacing(1)*double([0:origCtInfo(1).Columns-1]);
 y = coordsOfFirstPixel(2,1) + origCtInfo(1).ImageOrientationPatient(5) * ...
                               origCtInfo(1).PixelSpacing(2)*double([0:origCtInfo(1).Rows-1]);
 z = coordsOfFirstPixel(3,:);
+
+if xDir(1) == -1 && xDir(2) == 0 && xDir(3) == 0
+     x = flip(x,2);
+end
+
+if yDir(1) == 0 && yDir(2) == -1 && yDir(3) == 0
+    y = flip(y,2);
+end
 
 if exist('grid','var')
     xq = grid{1};
@@ -51,7 +62,13 @@ if exist('grid','var')
     yqRe = [coordsOfFirstPixel(2,1):origCtInfo(1).ImageOrientationPatient(5)*resolution.y: ...
         (coordsOfFirstPixel(2,1)+origCtInfo(1).ImageOrientationPatient(5)*origCtInfo(1).PixelSpacing(2)*double(origCtInfo(1).Rows-1))];
     zqRe = coordsOfFirstPixel(3,1):resolution.z: coordsOfFirstPixel(3,end);
+    if xDir(1) == -1 && xDir(2) == 0 && xDir(3) == 0
+     x = flip(x,2);
+    end
     
+    if yDir(1) == 0 && yDir(2) == -1 && yDir(3) == 0
+        y = flip(y,2);
+    end
     % cut values
     xq(xq < min(xqRe)) = [];
     xq(xq > max(xqRe)) = [];
@@ -94,6 +111,12 @@ else
         yq = [coordsOfFirstPixel(2,1):origCtInfo(1).ImageOrientationPatient(5)*resolution.y: ...
         (coordsOfFirstPixel(2,1)+origCtInfo(1).ImageOrientationPatient(5)*origCtInfo(1).PixelSpacing(2)*double(origCtInfo(1).Rows-1))];
         zq = coordsOfFirstPixel(3,1):resolution.z: coordsOfFirstPixel(3,end);
+        if xDir(1) == -1 && xDir(2) == 0 && xDir(3) == 0
+          xq = flip(xq,2);
+        end 
+        if yDir(1) == 0 && yDir(2) == -1 && yDir(3) == 0
+            yq = flip(yq,2);
+        end
         % set up grid matrices - implicit dimension permuation (X Y Z-> Y X Z)
         % Matlab represents internally in the first matrix dimension the
         % ordinate axis and in the second matrix dimension the abscissas axis


### PR DESCRIPTION
Because ct.x,y,z vectors were not fliped the dose calculation was producing errors,
so flip orientation of x,y,z vectors if ct.cube orientation is also flipped during interpolation
This means that we no longer have to flip the index cube in the RtssContours function