### PR TITLE
Bugfix: default parameters used ONLY if not available

### DIFF
--- a/matRad/matRad_generateStf.m
+++ b/matRad/matRad_generateStf.m
@@ -39,7 +39,12 @@ if nargin < 4
 end
 
 % load default parameters if not set
-pln = matRad_cfg.getDefaultProperties(pln,{'propOpt','propStf'});
+if ~isfield(pln,'propOpt')
+    pln = matRad_cfg.getDefaultProperties(pln,{'propOpt'});
+end
+if ~isfield(pln,'propStf')
+    pln = matRad_cfg.getDefaultProperties(pln,{'propStf'});
+end
 
 isExternalTherapy = any(strcmp(pln.radiationMode,{'photons','protons','helium','carbon'}));
 isPhotonTherapy = strcmp(pln.radiationMode,'photons');


### PR DESCRIPTION
generate stf uses default values of pln only if fields do not exist 