### PR TITLE
Possible bug in TOPAS engine with dij calculation

### DIFF
--- a/matRad/doseCalc/+DoseEngines/matRad_TopasMCEngine.m
+++ b/matRad/doseCalc/+DoseEngines/matRad_TopasMCEngine.m
@@ -2075,7 +2075,7 @@ classdef matRad_TopasMCEngine < DoseEngines.matRad_MonteCarloEngineAbstract
                             fprintf(fileID,'#-- time feature splitting for dij calculation\n');
                             fprintf(fileID,'s:Tf/ImageName/Function = "Step"\n');
                             % create time feature scorer and save with original rays and bixel names
-                            imageName = ['sv:Tf/ImageName/Values = ',num2str(cutNumOfBixel),cell2mat(strcat(strcat(' "ray',strsplit(num2str([dataTOPAS.ray]))),strcat('_bixel',strsplit(num2str([dataTOPAS.bixel])),'"')))];
+                            imageName = string(['sv:Tf/ImageName/Values = ',num2str(cutNumOfBixel),cell2mat(strcat(strcat(' "ray',strsplit(num2str([dataTOPAS.ray]))),strcat('_bixel',strsplit(num2str([dataTOPAS.bixel])),'"')))]);
                             fprintf(fileID,'%s\n',strjoin(imageName));
                             fprintf(fileID,'dv:Tf/ImageName/Times = Tf/Beam/Spot/Times ms\n');
                         end


### PR DESCRIPTION
strjoint requires a string not a char array. This is a possible fix, I only tested in one specific case, but it's a small fix.