### PR TITLE
DVH Widget Bugfix

### DIFF
--- a/matRad/gui/widgets/matRad_DVHWidget.m
+++ b/matRad/gui/widgets/matRad_DVHWidget.m
@@ -109,15 +109,24 @@ classdef matRad_DVHWidget < matRad_Widget
             resultGUI = evalin('base','resultGUI');
             pln = evalin('base','pln');
             cst = evalin('base','cst');
+            ct  = evalin('base','ct');
+
             % Calculate and show DVH
             doseCube = resultGUI.(this.selectedCube);
             dvh = matRad_calcDVH(cst,doseCube,'cum');
             
             matRad_showDVH(dvh,cst,pln,'axesHandle',this.dvhAx);
+
+            if ~isfield(pln,'multScen')
+                multScen = matRad_NominalScenario(ct);
+            else
+                multScen = pln.multScen;
+            end
+            multScen = matRad_ScenarioModel.create(multScen,ct);
             
             %check scenarios
-            if pln.multScen.totNumScen > 1
-                for i = 1:pln.multScen.totNumScen
+            if multScen.totNumScen > 1
+                for i = 1:multScen.totNumScen
                     scenFieldName = sprintf('%s_scen%d',this.selectedCube,i);
                     if isfield(resultGUI,scenFieldName)
                         tmpDvh = matRad_calcDVH(cst,resultGUI.(scenFieldName),'cum'); % Calculate cumulative scenario DVH

--- a/matRad/planAnalysis/matRad_showDVH.m
+++ b/matRad/planAnalysis/matRad_showDVH.m
@@ -163,7 +163,7 @@ if ~isempty(pln)
     pln.bioModel = matRad_BiologicalModel.validate(pln.bioModel,pln.radiationMode);
     
     if strcmp(pln.bioModel.model,'none')
-        xlabel('Dose [Gy]','FontSize',fontSizeValue);
+        xlabel(axesHandle,'Dose [Gy]','FontSize',fontSizeValue);
     else
         xlabel(axesHandle,'RBE x Dose [Gy(RBE)]','FontSize',fontSizeValue);
     end

--- a/test/gui/test_gui_DVHStatsWidget.m
+++ b/test/gui/test_gui_DVHStatsWidget.m
@@ -40,4 +40,61 @@ function test_DVHStatsWidget_constructor
     delete(h);
     close(get(p,'Parent'));
 
+function test_DVHStatsWidget_constructWithPhotonPln
+    evalin('base','load photons_testData.mat');
+    h = matRad_DVHStatsWidget();
+    h.selectedDisplayOption = 'physicalDose';
+    try
+        assertTrue(isa(h, 'matRad_DVHStatsWidget'));
+        assertTrue(isa(h, 'matRad_Widget'));
+    catch ME
+        evalin('base','clear ct cst pln stf dij resultGUI');
+        delete(h);
+        rethrow(ME);
+    end
+    evalin('base','clear ct cst pln stf dij resultGUI');
+    delete(h);
+
+function test_DVHStatsWidget_constructWithProtonPln
+    evalin('base','load protons_testData.mat');
+    h = matRad_DVHStatsWidget();
+    try
+        assertTrue(isa(h, 'matRad_DVHStatsWidget'));
+        assertTrue(isa(h, 'matRad_Widget'));
+    catch ME
+        evalin('base','clear ct cst pln stf dij resultGUI');
+        delete(h);
+        rethrow(ME);
+    end
+    evalin('base','clear ct cst pln stf dij resultGUI');
+    delete(h);
+
+function test_DVHStatsWidget_constructWithCarbonPln
+    evalin('base','load carbon_testData.mat');
+    h = matRad_DVHStatsWidget();
+    try
+        assertTrue(isa(h, 'matRad_DVHStatsWidget'));
+        assertTrue(isa(h, 'matRad_Widget'));
+    catch ME
+        evalin('base','clear ct cst pln stf dij resultGUI');
+        delete(h);
+        rethrow(ME);
+    end
+    evalin('base','clear ct cst pln stf dij resultGUI');
+    delete(h);
+
+function test_DVHStatsWidget_constructWithHeliumPln
+    evalin('base','load helium_testData.mat');
+    h = matRad_DVHStatsWidget();
+    try
+        assertTrue(isa(h, 'matRad_DVHStatsWidget'));
+        assertTrue(isa(h, 'matRad_Widget'));
+    catch ME
+        evalin('base','clear ct cst pln stf dij resultGUI');
+        delete(h);
+        rethrow(ME);
+    end
+    evalin('base','clear ct cst pln stf dij resultGUI');
+    delete(h);
+
 %TODO: Test Buttons / visibility depending on data

--- a/test/gui/test_gui_PlanWidget.m
+++ b/test/gui/test_gui_PlanWidget.m
@@ -40,7 +40,7 @@ function test_PlanWidget_constructor
     delete(h);
     close(get(p,'Parent'));
 
-function test_PlanWidget_constructWithData
+function test_PlanWidget_constructWithTG119
     evalin('base','load TG119.mat');
     h = matRad_PlanWidget();
     try
@@ -52,6 +52,63 @@ function test_PlanWidget_constructWithData
         rethrow(ME);
     end
     evalin('base','clear ct cst pln');
-    delete(h);   
+    delete(h);
 
-%TODO: Test Buttons / visibility depending on data
+function test_PlanWidget_constructWithPhotonPln
+    evalin('base','load photons_testData.mat');
+    h = matRad_PlanWidget();
+    try
+        assertTrue(isa(h, 'matRad_PlanWidget'));
+        assertTrue(isa(h, 'matRad_Widget'));
+    catch ME
+        evalin('base','clear ct cst pln stf dij resultGUI');
+        delete(h);
+        rethrow(ME);
+    end
+    evalin('base','clear ct cst pln stf dij resultGUI');
+    delete(h);
+
+function test_PlanWidget_constructWithProtonPln
+    evalin('base','load protons_testData.mat');
+    h = matRad_PlanWidget();
+    try
+        assertTrue(isa(h, 'matRad_PlanWidget'));
+        assertTrue(isa(h, 'matRad_Widget'));
+    catch ME
+        evalin('base','clear ct cst pln stf dij resultGUI');
+        delete(h);
+        rethrow(ME);
+    end
+    evalin('base','clear ct cst pln stf dij resultGUI');
+    delete(h);
+
+function test_PlanWidget_constructWithCarbonPln
+    evalin('base','load carbon_testData.mat');
+    h = matRad_PlanWidget();
+    try
+        assertTrue(isa(h, 'matRad_PlanWidget'));
+        assertTrue(isa(h, 'matRad_Widget'));
+    catch ME
+        evalin('base','clear ct cst pln stf dij resultGUI');
+        delete(h);
+        rethrow(ME);
+    end
+    evalin('base','clear ct cst pln stf dij resultGUI');
+    delete(h);
+
+function test_PlanWidget_constructWithHeliumPln
+    evalin('base','load helium_testData.mat');
+    h = matRad_PlanWidget();
+    try
+        assertTrue(isa(h, 'matRad_PlanWidget'));
+        assertTrue(isa(h, 'matRad_Widget'));
+    catch ME
+        evalin('base','clear ct cst pln stf dij resultGUI');
+        delete(h);
+        rethrow(ME);
+    end
+    evalin('base','clear ct cst pln stf dij resultGUI');
+    delete(h);
+
+
+%TODO: Test Buttons

--- a/test/gui/test_gui_exportWidget.m
+++ b/test/gui/test_gui_exportWidget.m
@@ -55,4 +55,18 @@ function test_exportWidget_constructWithData
     evalin('base','clear ct cst pln');
     delete(h);
 
+function test_exportWidget_constructWithCarbonPln
+    evalin('base','load carbon_testData.mat');
+    h = matRad_exportWidget();
+    try
+        assertTrue(isa(h, 'matRad_exportWidget'));
+        assertTrue(isa(h, 'matRad_Widget'));
+    catch ME
+        evalin('base','clear ct cst pln stf dij resultGUI');
+        delete(h);
+        rethrow(ME);
+    end
+    evalin('base','clear ct cst pln stf dij resultGUI');
+    delete(h);
+
 %TODO: Test Buttons / visibility depending on data

--- a/test/gui/test_gui_viewingWidget.m
+++ b/test/gui/test_gui_viewingWidget.m
@@ -40,7 +40,7 @@ function test_viewingWidget_constructor
     delete(h);
     close(get(p,'Parent'));
 
-function test_viewingWidget_constructWithData
+function test_viewingWidget_constructWithTG119
     evalin('base','load TG119.mat');
     h = matRad_ViewingWidget();
     try
@@ -51,6 +51,62 @@ function test_viewingWidget_constructWithData
         rethrow(ME);
     end
     evalin('base','clear ct cst pln');
+    delete(h);
+
+function test_ViewingWidget_constructWithPhotonPln
+    evalin('base','load photons_testData.mat');
+    h = matRad_ViewingWidget();
+    try
+        assertTrue(isa(h, 'matRad_ViewingWidget'));
+        assertTrue(isa(h, 'matRad_Widget'));
+    catch ME
+        evalin('base','clear ct cst pln stf dij resultGUI');
+        delete(h);
+        rethrow(ME);
+    end
+    evalin('base','clear ct cst pln stf dij resultGUI');
+    delete(h);
+
+function test_ViewingWidget_constructWithProtonPln
+    evalin('base','load protons_testData.mat');
+    h = matRad_ViewingWidget();
+    try
+        assertTrue(isa(h, 'matRad_ViewingWidget'));
+        assertTrue(isa(h, 'matRad_Widget'));
+    catch ME
+        evalin('base','clear ct cst pln stf dij resultGUI');
+        delete(h);
+        rethrow(ME);
+    end
+    evalin('base','clear ct cst pln stf dij resultGUI');
+    delete(h);
+
+function test_ViewingWidget_constructWithCarbonPln
+    evalin('base','load carbon_testData.mat');
+    h = matRad_ViewingWidget();
+    try
+        assertTrue(isa(h, 'matRad_ViewingWidget'));
+        assertTrue(isa(h, 'matRad_Widget'));
+    catch ME
+        evalin('base','clear ct cst pln stf dij resultGUI');
+        delete(h);
+        rethrow(ME);
+    end
+    evalin('base','clear ct cst pln stf dij resultGUI');
+    delete(h);
+
+function test_ViewingWidget_constructWithHeliumPln
+    evalin('base','load helium_testData.mat');
+    h = matRad_ViewingWidget();
+    try
+        assertTrue(isa(h, 'matRad_ViewingWidget'));
+        assertTrue(isa(h, 'matRad_Widget'));
+    catch ME
+        evalin('base','clear ct cst pln stf dij resultGUI');
+        delete(h);
+        rethrow(ME);
+    end
+    evalin('base','clear ct cst pln stf dij resultGUI');
     delete(h);
 
 %TODO: Test Buttons / visibility depending on data


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and testing of the `matRad` GUI widgets. The most important changes involve enhancing the `matRad_DVHWidget` and its `showDVH` function, updating the `matRad_showDVH` function, and adding new test cases for various widgets.

Enhancements to `showDVH` function:

* [`matRad/gui/widgets/matRad_DVHWidget.m`](diffhunk://#diff-bb3f453ff287944f886b7cfc9bf8c4c77b41418da601e3f50c266c948a51e89eR112-R129): Added logic to handle scenarios more robustly by introducing the `ct` variable and updating the scenario model creation and checks.

Updates to `matRad_showDVH` function:

* [`matRad/planAnalysis/matRad_showDVH.m`](diffhunk://#diff-3c4e755a209e77b5ea8a3ca1ccb68421a62bf6a7847f9aabd8f2ef1683c90021L166-R166): Modified the `xlabel` function to include the `axesHandle` parameter for better plot labeling.

Addition of new test cases:

* [`test/gui/test_gui_DVHStatsWidget.m`](diffhunk://#diff-2e4336456366022eb713fb60005e7f70564522a3da39c006d08b2b6fedbf2332R43-R99): Added multiple test functions to construct `DVHStatsWidget` with different plan types (Photon, Proton, Carbon, Helium) and verify their correct instantiation.
* [`test/gui/test_gui_PlanWidget.m`](diffhunk://#diff-38522405b566cd65b047ba8d4af567c3611d354d10aff7e9ea8357e24d9daffdL43-R43): Added test functions to construct `PlanWidget` with different plan types (TG119, Photon, Proton, Carbon, Helium) and verify their correct instantiation. [[1]](diffhunk://#diff-38522405b566cd65b047ba8d4af567c3611d354d10aff7e9ea8357e24d9daffdL43-R43) [[2]](diffhunk://#diff-38522405b566cd65b047ba8d4af567c3611d354d10aff7e9ea8357e24d9daffdL57-R114)
* [`test/gui/test_gui_exportWidget.m`](diffhunk://#diff-488a2a4e6963060f8a107b9067c5904ef2ce38cc3afd8cffb2a7872d350d3493R58-R71): Added a test function to construct `exportWidget` with a Carbon plan and verify its correct instantiation.
* [`test/gui/test_gui_viewingWidget.m`](diffhunk://#diff-84253d4db2d30f33115dc8bf114b4bc5f3bd27b06f0dc9ccc6e79bd4afa81a45L43-R43): Added test functions to construct `ViewingWidget` with different plan types (TG119, Photon, Proton, Carbon, Helium) and verify their correct instantiation. [[1]](diffhunk://#diff-84253d4db2d30f33115dc8bf114b4bc5f3bd27b06f0dc9ccc6e79bd4afa81a45L43-R43) [[2]](diffhunk://#diff-84253d4db2d30f33115dc8bf114b4bc5f3bd27b06f0dc9ccc6e79bd4afa81a45R56-R111)