### PR TITLE
Small DICOM Export / Import fixes

### DIFF
--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -41,5 +41,5 @@ jobs:
               uses: codecov/test-results-action@v1
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
-                  files: test-results/test-results/matlab-R2022b/coverage.xml,test-results/matlab-latest/coverage.xml,test-results/octave/coverage.xml
+                  files: test-results/matlab-R2022b/testresults.xml,test-results/matlab-latest/testresults.xml,test-results/octave/testresults.xml
             

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
 ## Development Changes
-- Bugfix for DVH widget to not throw a warning in updates, handle scenarios correctly / more robustly and missing xlabel axesHandle parameter.
+
+### Bug Fixes
+- DICOM Import widget allow selection of multiple RTDose files.
+- DICOM Import Widget and importer handle selected patient more consistently and robustly. 
+- DICOM Exporter writes quantities beyond dose, importer tries to import them correctly.
+- DICOM Exporter now always writes ReferencedRTPlanSequence. Importer can now survive without it.
+- DVH widget does not throw a warning in updates, handle scenarios correctly / more robustly and missing xlabel axesHandle parameter.
+
 
 ## Version 3.1.0 - "Cleve"
 

--- a/matRad/dicom/@matRad_DicomExporter/matRad_exportDicomRTDoses.m
+++ b/matRad/dicom/@matRad_DicomExporter/matRad_exportDicomRTDoses.m
@@ -126,14 +126,14 @@ obj.rtDoseMetas = struct([]);
 obj.rtDoseExportStatus = struct([]);
 
 for i = 1:numel(doseFieldNames)
-    doseName = doseFieldNames{i};
+    doseName = doseFieldNames{i};    
     
     %Now check if we export physical or RBE weighted dose, they are known
     %to dicom
-    if strncmp(doseName,'physicalDose',12)
+    if strncmp(doseName,'physicalDose',12) || strncmp(doseName,'LET',3)
         doseType = 'PHYSICAL';
-    elseif strncmp(doseName,'RBExDose',8)
-        doseType = 'EFFECTIVE';
+    elseif strncmp(doseName,'RBExDose',8) || strncmp(doseName,'BED',3) || strncmp(doseName,'alpha',3) || strncmp(doseName,'beta',3)
+        doseType = 'EFFECTIVE';        
     else
         matRad_cfg.dispInfo('Dose Cube ''%s'' of unknown type for DICOM. Not exported!\n',doseName);
         continue;
@@ -165,6 +165,7 @@ for i = 1:numel(doseFieldNames)
     metaCube = meta;
     metaCube.DoseType = doseType;
     metaCube.DoseSummationType = deliveryType;
+    metaCube.DoseComment = doseName;
        
     %ID of the RTDose
     metaCube.SeriesInstanceUID = dicomuid;    

--- a/matRad/dicom/@matRad_DicomExporter/matRad_exportDicomRTDoses.m
+++ b/matRad/dicom/@matRad_DicomExporter/matRad_exportDicomRTDoses.m
@@ -44,7 +44,6 @@ meta.FrameOfReferenceUID = obj.FrameOfReferenceUID;
 
 meta.Modality = 'RTDOSE';
 meta.Manufacturer = '';
-meta.DoseUnits = 'GY';
 
 %Reference
 %ID of the CT
@@ -127,13 +126,17 @@ obj.rtDoseExportStatus = struct([]);
 
 for i = 1:numel(doseFieldNames)
     doseName = doseFieldNames{i};    
+    doseUnits = 'GY';
     
     %Now check if we export physical or RBE weighted dose, they are known
     %to dicom
     if strncmp(doseName,'physicalDose',12) || strncmp(doseName,'LET',3)
         doseType = 'PHYSICAL';
-    elseif strncmp(doseName,'RBExDose',8) || strncmp(doseName,'BED',3) || strncmp(doseName,'alpha',3) || strncmp(doseName,'beta',3)
-        doseType = 'EFFECTIVE';        
+    elseif strncmp(doseName,'RBExDose',8) || strncmp(doseName,'BED',3) || strncmp(doseName,'alpha',3) || strncmp(doseName,'beta',3) || strncmp(doseName,'effect',6) || strncmp(doseName,'RBE',3)
+        doseType = 'EFFECTIVE';
+        if strncmp(doseName,'RBE',3)
+            doseUnits = 'RELATIVE';
+        end
     else
         matRad_cfg.dispInfo('Dose Cube ''%s'' of unknown type for DICOM. Not exported!\n',doseName);
         continue;
@@ -166,6 +169,7 @@ for i = 1:numel(doseFieldNames)
     metaCube.DoseType = doseType;
     metaCube.DoseSummationType = deliveryType;
     metaCube.DoseComment = doseName;
+    metaCube.DoseUnits = doseUnits;
        
     %ID of the RTDose
     metaCube.SeriesInstanceUID = dicomuid;    

--- a/matRad/dicom/@matRad_DicomImporter/matRad_DicomImporter.m
+++ b/matRad/dicom/@matRad_DicomImporter/matRad_DicomImporter.m
@@ -26,7 +26,8 @@ classdef matRad_DicomImporter < handle
 
        % lists of all files
        allfiles;
-       patient;
+       patients;
+       selectedPatient;
        importFiles; % all the names (directories) of files, that will be imported
 
        % properties with data for import functions

--- a/matRad/dicom/@matRad_DicomImporter/matRad_importDicomRTDose.m
+++ b/matRad/dicom/@matRad_DicomImporter/matRad_importDicomRTDose.m
@@ -75,7 +75,7 @@ for i = 1 : numDoseFiles
             doseTypeHelper = 'physicalDose';
         end
     elseif strncmpi(doseTypeHelper,'EFFECTIVE',6)
-        if any(strcmp(doseComment,{'RBExDose','BED','alpha','beta'}))
+        if any(strcmp(doseComment,{'RBExDose','BED','alpha','beta','effect','RBE'}))
             doseTypeHelper = doseComment;
         else
             doseTypeHelper = 'RBExDose';

--- a/matRad/dicom/@matRad_DicomImporter/matRad_importDicomRTDose.m
+++ b/matRad/dicom/@matRad_DicomImporter/matRad_importDicomRTDose.m
@@ -62,11 +62,24 @@ for i = 1 : numDoseFiles
     else
         doseInstanceHelper = [];
     end
-    
+
+    doseComment = '';
+    if isfield(dose.(itemName).dicomInfo,'DoseComment')
+        doseComment = dose.(itemName).dicomInfo.DoseComment;
+    end
+            
     if strncmpi(doseTypeHelper,'PHYSICAL',6)
-        doseTypeHelper = 'physicalDose';
+        if any(strcmp(doseComment,{'physicalDose','LET'}))
+            doseTypeHelper = doseComment;
+        else
+            doseTypeHelper = 'physicalDose';
+        end
     elseif strncmpi(doseTypeHelper,'EFFECTIVE',6)
-        doseTypeHelper = 'RBExDose';
+        if any(strcmp(doseComment,{'RBExDose','BED','alpha','beta'}))
+            doseTypeHelper = doseComment;
+        else
+            doseTypeHelper = 'RBExDose';
+        end
     end
     
     %If given as plan and not per fraction

--- a/matRad/dicom/@matRad_DicomImporter/matRad_scanDicomImportFolder.m
+++ b/matRad/dicom/@matRad_DicomImporter/matRad_scanDicomImportFolder.m
@@ -246,9 +246,9 @@ if ~isempty(obj.allfiles)
     close(h)
     
     if ~isempty(obj.allfiles)
-        obj.patient = unique(obj.allfiles(:,3));
+        obj.patients = unique(obj.allfiles(:,3));
         
-        if isempty(obj.patient)
+        if isempty(obj.patients)
              matRad_cfg.dispError('No patient found with DICOM CT _and_ RT structure set in patient directory!');
         end
     else

--- a/matRad/gui/widgets/matRad_importDicomWidget.m
+++ b/matRad/gui/widgets/matRad_importDicomWidget.m
@@ -174,8 +174,8 @@ classdef matRad_importDicomWidget < matRad_Widget
             % to pass only selected objects to the matRad_importDicom
             % selected patient
             if ~isempty(handles.patient_listbox)
-                selected_patient = this.importer.patient{get(handles.patient_listbox,'Value')};
-                this.importer.patient = selected_patient;
+                selected_patient = get(handles.patient_listbox,'Value');
+                this.importer.selectedPatient = selected_patient;
             end
 
             % selected CT serie
@@ -222,7 +222,7 @@ classdef matRad_importDicomWidget < matRad_Widget
 
             %% save ct, cst, pln, dose
             matRad_cfg = MatRad_Config.instance();
-            matRadFileName = fullfile(matRad_cfg.userfolders{1},[this.importer.patient '.mat']); % use default from dicom
+            matRadFileName = fullfile(matRad_cfg.userfolders{1},[this.importer.patients{this.importer.selectedPatient} '.mat']); % use default from dicom
             [FileName,PathName] = uiputfile('*.mat','Save as...',matRadFileName);
             ct = this.importer.ct;
             cst = this.importer.cst;
@@ -970,13 +970,15 @@ classdef matRad_importDicomWidget < matRad_Widget
 
             this.importer = matRad_DicomImporter(get(handles.dir_path_field,'String'));
 
-            if iscell(this.importer.patient)
-                handles.fileList =  this.importer.allfiles;
-                %handles.patient_listbox.String = patient_listbox;
-                set(handles.patient_listbox,'String',this.importer.patient,'Value',1);
-                % guidata(hObject, handles);
-                this.handles = handles;
+            handles.fileList =  this.importer.allfiles;
+            %handles.patient_listbox.String = patient_listbox;
+            if isempty(this.importer.selectedPatient) || this.importer.selectedPatient > numel(this.importer.patients)
+                this.importer.selectedPatient = 1;
             end
+                
+            set(handles.patient_listbox,'String',this.importer.patients,'Value',this.importer.selectedPatient);
+            % guidata(hObject, handles);
+            this.handles = handles;
         end
     end
     

--- a/matRad/gui/widgets/matRad_importDicomWidget.m
+++ b/matRad/gui/widgets/matRad_importDicomWidget.m
@@ -211,7 +211,7 @@ classdef matRad_importDicomWidget < matRad_Widget
             % selected dose serie
             allRTDoses = this.importer.importFiles.rtdose;
             if ~isempty(allRTDoses) && ~isempty(handles.doseseries_listbox.Value)
-                UIDSelected_rtdose = handles.doseseries_listbox.String{get(handles.doseseries_listbox,'Value'), 1};
+                UIDSelected_rtdose = handles.doseseries_listbox.String(get(handles.doseseries_listbox,'Value'));
                 selectedRTDose = allRTDoses(strcmp(allRTDoses(:, 4), UIDSelected_rtdose), :);
                 this.importer.importFiles.rtdose = selectedRTDose;
             else 


### PR DESCRIPTION
This pull request fixes #797 and #798 in `matRad`'s DICOM importer and exporter functionalities. The most important changes involve adding support for new dose types and comments, updating patient data handling, and ensuring compliance with DICOM standards.

### DICOM Exporter Improvements:
* Added support for new dose types such as `LET`, `BED`, `alpha`, `beta`, `effect`, and `RBE` in `matRad_exportDicomRTDoses.m`. This includes setting `doseUnits` to `RELATIVE` when appropriate. [[1]](diffhunk://#diff-1fcd053e2bd74806054295b065ac8115df66a511722b700bdc9a2994867137d5L114-R139) [[2]](diffhunk://#diff-1fcd053e2bd74806054295b065ac8115df66a511722b700bdc9a2994867137d5R171-R172)
* Ensured `ReferencedRTPlanSequence` is set as it is a conditionally required field according to the DICOM standard.

### DICOM Importer Enhancements:
* Updated `matRad_DicomImporter` to handle multiple patients and selected patients. This includes changes to the `patients` and `selectedPatient` properties and their usage in various methods. [[1]](diffhunk://#diff-8cb79425867c53ac155be2efd4e9b2f3eb4e0ab64869cae695e38b6d533a1c6aL29-R30) [[2]](diffhunk://#diff-927092f8196b46a5e994bae071ce13f8c16b8098d549896ee26d0601ccb73154L249-R251) [[3]](diffhunk://#diff-5c8b48f042e956516fedb74855dd655e238e3eae5b0d5dc37f7190f17f541a1dL177-R178) [[4]](diffhunk://#diff-5c8b48f042e956516fedb74855dd655e238e3eae5b0d5dc37f7190f17f541a1dL973-L981)
* Added handling for `DoseComment` in `matRad_importDicomRTDose.m` to map dose comments to dose types.

Fixes #797, #798