### PR TITLE
Bugfix for Brachy Therapy Stf Generator

### DIFF
--- a/examples/matRad_example15_brachy.m
+++ b/examples/matRad_example15_brachy.m
@@ -84,13 +84,11 @@ cst{9,6}{1} = struct(DoseObjectives.matRad_MeanDose(1));
 % Here we will use HDR. By this means matRad will look for 'brachy_HDR.mat'
 % in our root directory and will use the data provided in there for 
 % dose calculation.
-
 pln.radiationMode   = 'brachy'; 
 pln.machine         = 'HDR';    % 'LDR' or 'HDR' for brachy
 
 pln.bioModel        = 'none';
 pln.multScen        = 'nomScen';
-
 
 %% II.1 - needle and template geometry
 % Now we have to set some parameters for the template and the needles. 
@@ -110,6 +108,7 @@ pln.propStf.needle.seedsNo           = 6;
 % The needles will be positioned right under the target volume pointing up.
 
 
+pln.propStf.visMode      = 1; %Enable visualization for stf generation
 pln.propStf.bixelWidth   = 5; % [mm] template grid distance
 
 %Template Type
@@ -151,15 +150,11 @@ end
 % needles.
 % Calculation time will be reduced by one tenth when we define a dose
 % cutoff distance.
-
-
 pln.propDoseCalc.TG43approximation = '2D'; %'1D' or '2D' 
 
 pln.propDoseCalc.doseGrid.resolution.x = 5; % [mm]
 pln.propDoseCalc.doseGrid.resolution.y = 5; % [mm]
 pln.propDoseCalc.doseGrid.resolution.z = 5; % [mm]
-
-
 
 % We can also use other solver for optimization than IPOPT. matRad 
 % currently supports simulannealbnd from the MATLAB Global Optimization Toolbox. First we
@@ -172,7 +167,6 @@ else
     pln.propOpt.optimizer = 'IPOPT';
 end
 
-pln.propOpt.optimizer = 'IPOPT';
 %% II.1 - book keeping
 % Some field names have to be kept although they don't have a direct
 % relevance for brachy therapy.
@@ -182,13 +176,11 @@ pln.numOfFractions          = 1;
 % Et voila! Our treatment plan structure is ready. Lets have a look:
 disp(pln);
 
-
 %% II.2 Steering Seed Positions From STF
 % The steering file struct contains all needls/catheter geometry with the
 % target volume, number of needles, seeds and the positions of all needles
 % The one in the end enables visualization.
 stf = matRad_generateStf(ct,cst,pln);
-
 
 %% II.2 - view stf
 % The 3D view is interesting, but we also want to know how the stf struct

--- a/matRad/IO/matRad_writeNifTI.m
+++ b/matRad/IO/matRad_writeNifTI.m
@@ -63,6 +63,9 @@ info.PixelDimensions = [metadata.resolution(metadata.axisPermutation)];
 info.Datatype = metadata.datatype;
 info.ImageSize = size(cube);
 info.Description = sprintf('Exported from matRad %s',matRad_version());
+if length(info.Description) >= 80
+    info.Description = info.Description(1:79);
+end
 
 if max(info.ImageSize) > 32767
     info.Version = 'NIfTI2';

--- a/matRad/steering/matRad_StfGeneratorBrachy.m
+++ b/matRad/steering/matRad_StfGeneratorBrachy.m
@@ -148,7 +148,7 @@ classdef matRad_StfGeneratorBrachy < matRad_StfGeneratorBase
                 % Prostate = plot3(TargX, TargY, TargZ, '.', 'Color', 'b', 'DisplayName', 'prostate');
 
                 % Prepare points for boundary calculation
-                P = [TargX', TargY', TargZ'];
+                P = [TargX, TargY, TargZ];
 
                 if ~isempty(P)
                     % Determine the environment


### PR DESCRIPTION
This pull request includes changes to the `matRad_example15_brachy.m` and `matRad_StfGeneratorBrachy.m` files to improve the readability and functionality of the brachytherapy example and steering file generation.

Improvements to `matRad_example15_brachy.m`:

* Removed unnecessary blank lines to improve code readability. [[1]](diffhunk://#diff-bfdc53d96aead67d1fb8925319545623f6dc8b5f951fb91409ea566d2a527e9dL87-L94) [[2]](diffhunk://#diff-bfdc53d96aead67d1fb8925319545623f6dc8b5f951fb91409ea566d2a527e9dL154-L163) [[3]](diffhunk://#diff-bfdc53d96aead67d1fb8925319545623f6dc8b5f951fb91409ea566d2a527e9dL175) [[4]](diffhunk://#diff-bfdc53d96aead67d1fb8925319545623f6dc8b5f951fb91409ea566d2a527e9dL185-L192)
* Added a `pln.propStf.visMode` to enable visualization for STF generation in the example.

Enhancement in `matRad_StfGeneratorBrachy.m`:

* Corrected the boundary calculation by removing the transpose operation on the target point coordinates.