### PR TITLE
Persistent Caching of available Implementations (Dose Engines, Stf Generators, etc.)

### DIFF
--- a/matRad/bioModels/matRad_BiologicalModel.m
+++ b/matRad/bioModels/matRad_BiologicalModel.m
@@ -126,7 +126,13 @@ classdef (Abstract) matRad_BiologicalModel < handle
             %Use the root folder and the biomodel folder only
             folders = {fileparts(mfilename('fullpath'))};
             folders = [folders matRad_cfg.userfolders];
-            metaBioModels = matRad_findSubclasses(meta.class.fromName(mfilename('class')),'folders',folders,'includeSubfolders',true);
+
+            persistent metaBioModels lastOptionalPaths
+            if isempty(metaBioModels) || (~isempty(lastOptionalPaths) && ~isequal(lastOptionalPaths, folders))
+                lastOptionalPaths = folders;
+                metaBioModels = matRad_findSubclasses(meta.class.fromName(mfilename('class')),'folders',folders,'includeSubfolders',true);
+            end
+            
             classList = matRad_identifyClassesByConstantProperties(metaBioModels,'model','defaults',{'none'});
 
             if nargin > 0 

--- a/matRad/doseCalc/+DoseEngines/@matRad_DoseEngineBase/getAvailableEngines.m
+++ b/matRad/doseCalc/+DoseEngines/@matRad_DoseEngineBase/getAvailableEngines.m
@@ -36,7 +36,13 @@ end
 
 %Get available, valid classes through call to matRad helper function
 %for finding subclasses
-availableDoseEngines = matRad_findSubclasses('DoseEngines.matRad_DoseEngineBase','packages',{'DoseEngines'},'folders',optionalPaths,'includeAbstract',false);
+persistent allAvailableDoseEngines lastOptionalPaths
+if isempty(allAvailableDoseEngines) || (~isempty(lastOptionalPaths) && ~isequal(lastOptionalPaths, optionalPaths))
+    lastOptionalPaths = optionalPaths;
+    allAvailableDoseEngines = matRad_findSubclasses('DoseEngines.matRad_DoseEngineBase','packages',{'DoseEngines'},'folders',optionalPaths,'includeAbstract',false);
+end
+
+availableDoseEngines = allAvailableDoseEngines;
 
 %Now filter for pln
 ix = [];

--- a/matRad/gui/widgets/matRad_PlanWidget.m
+++ b/matRad/gui/widgets/matRad_PlanWidget.m
@@ -804,7 +804,7 @@ classdef matRad_PlanWidget < matRad_Widget
 
             matRad_cfg = MatRad_Config.instance();
 
-            stfGen = matRad_StfGeneratorBase.getGeneratorFromPln(pln);
+            stfGen = matRad_StfGeneratorBase.getGeneratorFromPln(pln, false);
 
             set(handles.editBixelWidth,'String',num2str(stfGen.bixelWidth));
             set(handles.editGantryAngle,'String',num2str(stfGen.gantryAngles));

--- a/matRad/scenarios/matRad_ScenarioModel.m
+++ b/matRad/scenarios/matRad_ScenarioModel.m
@@ -232,7 +232,12 @@ classdef (Abstract) matRad_ScenarioModel < handle
             %Use the root folder and the scenarios folder only
             folders = {fileparts(mfilename('fullpath'))};
             folders = [folders matRad_cfg.userfolders];
-            metaScenarioModels = matRad_findSubclasses(meta.class.fromName(mfilename('class')),'folders',folders,'includeSubfolders',true);
+
+            persistent metaScenarioModels lastOptionalPaths
+            if isempty(metaScenarioModels) || (~isempty(lastOptionalPaths) && ~isequal(lastOptionalPaths, folders))
+                lastOptionalPaths = folders;
+                metaScenarioModels = matRad_findSubclasses(meta.class.fromName(mfilename('class')),'folders',folders,'includeSubfolders',true);
+            end
             classList = matRad_identifyClassesByConstantProperties(metaScenarioModels,'shortName','defaults',{'nomScen'});
 
             if isempty(classList)

--- a/matRad/steering/matRad_StfGeneratorBase.m
+++ b/matRad/steering/matRad_StfGeneratorBase.m
@@ -439,7 +439,13 @@ classdef (Abstract) matRad_StfGeneratorBase < handle
 
             %Get available, valid classes through call to matRad helper function
             %for finding subclasses
-            availableStfGenerators = matRad_findSubclasses(mfilename('class'),'folders',optionalPaths,'includeAbstract',false);
+            persistent allAvailableStfGenerators lastOptionalPaths
+            if isempty(allAvailableStfGenerators) || (~isempty(lastOptionalPaths) && ~isequal(lastOptionalPaths, optionalPaths))
+                lastOptionalPaths = optionalPaths;
+                allAvailableStfGenerators = matRad_findSubclasses(mfilename('class'),'folders',optionalPaths,'includeAbstract',false);
+            end
+
+            availableStfGenerators = allAvailableStfGenerators;
 
             %Now filter for pln
             ix = [];

--- a/matRad/steering/matRad_StfGeneratorBase.m
+++ b/matRad/steering/matRad_StfGeneratorBase.m
@@ -337,9 +337,13 @@ classdef (Abstract) matRad_StfGeneratorBase < handle
     end
 
     methods (Static)
-        function generator = getGeneratorFromPln(pln)
+        function generator = getGeneratorFromPln(pln, warnDefault)
             %GETENGINE Summary of this function goes here
             %   Detailed explanation goes here
+
+            if nargin < 2
+                warnDefault = true;
+            end
 
             matRad_cfg = MatRad_Config.instance();
 
@@ -384,7 +388,9 @@ classdef (Abstract) matRad_StfGeneratorBase < handle
                         generatorHandle = generatorHandle{1};
                     end
                     generator = generatorHandle(pln);
-                    matRad_cfg.dispWarning('Using default stf generator %s!', generator.name);
+                    if warnDefault
+                        matRad_cfg.dispWarning('Using default stf generator %s!', generator.name);
+                    end
                 elseif ~isempty(classList)
                     generatorHandle = classList(1).handle;
                     generator = generatorHandle(pln);


### PR DESCRIPTION
The most important changes involve the introduction of persistent variables to cache the available implementations for DoseEngines, StfGenerators, ScenarioModels and BioModels to avoid slow response when operating in large paths. Further, we allow suppression of the warning message when the default generator is used.

Caching improvements:

* [`matRad/bioModels/matRad_BiologicalModel.m`](diffhunk://#diff-190cbf0aaf651804cc09002d14e50bb2605885911b957ef661396cd268038464R129-R135): Added persistent variables `metaBioModels` and `lastOptionalPaths` to cache the results of `matRad_findSubclasses` and avoid redundant computations.
* [`matRad/doseCalc/+DoseEngines/@matRad_DoseEngineBase/getAvailableEngines.m`](diffhunk://#diff-64975f40adf4f5a30a602759d2896d66973a818e0adaca1af04517a18359a9dfL39-R45): Introduced persistent variables `allAvailableDoseEngines` and `lastOptionalPaths` to cache the list of available dose engines.
* [`matRad/scenarios/matRad_ScenarioModel.m`](diffhunk://#diff-bfccbe71ed0c02ef7f4f89963045ef163b4c9bc0d41d6e2881d2f5440aaa870fR235-R240): Implemented persistent variables `metaScenarioModels` and `lastOptionalPaths` to store the results of `matRad_findSubclasses` for scenario models.
* [`matRad/steering/matRad_StfGeneratorBase.m`](diffhunk://#diff-591fa20aa8b97c3b4b1b4af0799b9356b2065d5605a8e839c16a3e3f3e944f7aL442-R454): Added persistent variables `allAvailableStfGenerators` and `lastOptionalPaths` to cache the available STF generators.

Functionality enhancement:

* [`matRad/steering/matRad_StfGeneratorBase.m`](diffhunk://#diff-591fa20aa8b97c3b4b1b4af0799b9356b2065d5605a8e839c16a3e3f3e944f7aL340-R347): Modified the `getGeneratorFromPln` method to include a new parameter `warnDefault` that controls whether a warning message is displayed when the default STF generator is used. [[1]](diffhunk://#diff-591fa20aa8b97c3b4b1b4af0799b9356b2065d5605a8e839c16a3e3f3e944f7aL340-R347) [[2]](diffhunk://#diff-591fa20aa8b97c3b4b1b4af0799b9356b2065d5605a8e839c16a3e3f3e944f7aR391-R393)