### PR TITLE
Enhance plotting functionality of plot slice wrapper

### DIFF
--- a/examples/matRad_example2_photons.m
+++ b/examples/matRad_example2_photons.m
@@ -197,18 +197,26 @@ resultGUI_coarse         = matRad_fluenceOptimization(dij,cst,pln);
 plane      = 3;
 doseWindow = [0 max([resultGUI.physicalDose(:); resultGUI_coarse.physicalDose(:)])];
 
-figure,title('original plan - fine beam spacing')
-matRad_plotSliceWrapper(gca,ct,cst,1,resultGUI.physicalDose,plane,slice,[],0.75,colorcube,[],doseWindow,[]);
-figure,title('modified plan - coarse beam spacing')
-matRad_plotSliceWrapper(gca,ct,cst,1,resultGUI_coarse.physicalDose,plane,slice,[],0.75,colorcube,[],doseWindow,[]);
+% Create figure for the original plan
+figure
+titleString = 'Original Plan - Fine Beam Spacing';
+matRad_plotSliceWrapper(gca,ct,cst,1,resultGUI.physicalDose,plane,slice,[],0.75,colorcube,[],doseWindow,[],[],[],false,titleString);
+
+% Create figure for the modified plan
+figure
+titleString = 'Modified Plan - Coarse Beam Spacing';
+matRad_plotSliceWrapper(gca,ct,cst,1,resultGUI_coarse.physicalDose,plane,slice,[],0.75,colorcube,[],doseWindow,[],[],[],false,titleString);
 
 %% 
 % At this point we would like to see the absolute difference of the first 
 % optimization (finer beam spacing) and the second optimization (coarser 
 % beam spacing)
 absDiffCube = resultGUI.physicalDose-resultGUI_coarse.physicalDose;
-figure,title( 'fine beam spacing plan - coarse beam spacing plan')
-matRad_plotSliceWrapper(gca,ct,cst,1,absDiffCube,plane,slice,[],[],colorcube);
+
+% Create figure for the difference plot
+figure
+titleString = 'Fine Beam Spacing Plan - Coarse Beam Spacing Plan';
+matRad_plotSliceWrapper(gca,ct,cst,1,absDiffCube,plane,slice,[],[],colorcube,[],[],[],[],[],false,titleString);
 
 %% Obtain dose statistics
 % Two more columns will be added to the cst structure depicting the DVH and
@@ -222,7 +230,7 @@ resultGUI_coarse = matRad_planAnalysis(resultGUI_coarse,ct,cst,stf,pln);
 % both plans
 ixOAR = 2;
 disp(resultGUI.qi(ixOAR).D_95);
-disp(resultGUI.qi_coarse(ixOAR).D_95);
+disp(resultGUI_coarse.qi(ixOAR).D_95);
 
 
 %% 

--- a/matRad/plotting/matRad_plotAxisLabels.m
+++ b/matRad/plotting/matRad_plotAxisLabels.m
@@ -1,11 +1,10 @@
-function  matRad_plotAxisLabels(axesHandle,ct,plane,slice,defaultFontSize,tickdist)
+function  matRad_plotAxisLabels(axesHandle,ct,plane,slice,defaultFontSize,titleString)
 % matRad function to plot x and y labels denoting the ct dimensions 
 % according to the selected plane
 %
 % call
 %   matRad_plotAxisLabels(axesHandle,ct,plane,slice,defaultFontSize)
-%   matRad_plotAxisLabels(axesHandle,ct,plane,slice,defaultFontSize,
-%   tickdist)
+%   matRad_plotAxisLabels(axesHandle,ct,plane,slice,defaultFontSize,titleString)
 %
 % input
 %   axesHandle         handle to axes the slice should be displayed in
@@ -13,6 +12,7 @@ function  matRad_plotAxisLabels(axesHandle,ct,plane,slice,defaultFontSize,tickdi
 %   plane              plane view (coronal=1,sagittal=2,axial=3)
 %   slice              slice in the selected plane of the 3D cube
 %   defaultFontSize    default font size as double value
+%   titleString        optional custom title to display above plane information
 %
 % output
 %   -
@@ -39,15 +39,14 @@ if ~exist('defaultFontSize','var') || isempty(defaultFontSize)
     defaultFontSize = matRad_cfg.gui.fontSize;
 end
 
-ct = matRad_getWorldAxes(ct);
-
-
-if ~exist('tickdist','var') || isempty(tickdist)
-     tickdist = abs(ct.x(end)-ct.x(1))/10;
+if ~exist('titleString','var') || isempty(titleString)
+    titleString = '';
 end
 
+ct = matRad_getWorldAxes(ct);
+
 %% Set axis labels and plot iso center
-if  plane == 3% Axial plane
+if plane == 3 % Axial plane
     if ~isempty(ct.resolution.x) && ~isempty(ct.resolution.y)
         set(axesHandle,'XTick',linspace(0,ct.x(end)-ct.x(1),10)./ct.resolution.x); 
         set(axesHandle,'YTick',linspace(0,ct.y(end)-ct.y(1),10)./ct.resolution.y);
@@ -56,11 +55,11 @@ if  plane == 3% Axial plane
         xlabel(axesHandle,'x [mm]','FontSize',defaultFontSize)
         ylabel(axesHandle,'y [mm]','FontSize',defaultFontSize)
         vcoord = matRad_cubeIndex2worldCoords([1,1,slice],ct);
-        title(axesHandle,['axial plane z = ' num2str(vcoord(3)) ' [mm]'],'FontSize',defaultFontSize,'Color',matRad_cfg.gui.highlightColor);
+        planeInfo = ['axial plane z = ' num2str(vcoord(3)) ' [mm]'];
     else
         xlabel(axesHandle,'x [voxels]','FontSize',defaultFontSize)
         ylabel(axesHandle,'y [voxels]','FontSize',defaultFontSize)
-        title(axesHandle,'axial plane','FontSize',defaultFontSize,'Color',matRad_cfg.gui.highlightColor)
+        planeInfo = 'axial plane';
     end
 elseif plane == 2 % Sagittal plane
     if ~isempty(ct.resolution.y) && ~isempty(ct.resolution.z)
@@ -71,11 +70,11 @@ elseif plane == 2 % Sagittal plane
         xlabel(axesHandle,'z [mm]','FontSize',defaultFontSize);
         ylabel(axesHandle,'y [mm]','FontSize',defaultFontSize);
         vcoord = matRad_cubeIndex2worldCoords([1,slice,1],ct);
-        title(axesHandle,['sagittal plane x = ' num2str(vcoord(1)) ' [mm]'],'FontSize',defaultFontSize,'Color',matRad_cfg.gui.highlightColor);
+        planeInfo = ['sagittal plane x = ' num2str(vcoord(1)) ' [mm]'];
     else
         xlabel(axesHandle,'z [voxels]','FontSize',defaultFontSize)
         ylabel(axesHandle,'y [voxels]','FontSize',defaultFontSize)
-        title(axesHandle,'sagittal plane','FontSize',defaultFontSize,'Color',matRad_cfg.gui.highlightColor);
+        planeInfo = 'sagittal plane';
     end
 elseif plane == 1 % Coronal plane
     if ~isempty(ct.resolution.x) && ~isempty(ct.resolution.z)
@@ -86,16 +85,27 @@ elseif plane == 1 % Coronal plane
         xlabel(axesHandle,'z [mm]','FontSize',defaultFontSize)
         ylabel(axesHandle,'x [mm]','FontSize',defaultFontSize)
         vcoord = matRad_cubeIndex2worldCoords([slice,1,1],ct);
-        title(axesHandle,['coronal plane y = ' num2str(vcoord(2)) ' [mm]'],'FontSize',defaultFontSize,'Color',matRad_cfg.gui.highlightColor)
+        planeInfo = ['coronal plane y = ' num2str(vcoord(2)) ' [mm]'];
     else
         xlabel(axesHandle,'z [voxels]','FontSize',defaultFontSize)
         ylabel(axesHandle,'x [voxels]','FontSize',defaultFontSize)
-        title(axesHandle,'coronal plane','FontSize',defaultFontSize,'Color',matRad_cfg.gui.highlightColor)
+        planeInfo = 'coronal plane';
     end
 end
+
+% Create the combined title if a custom title is provided
+if ~isempty(titleString)
+    titleText = sprintf('%s\n%s', titleString, planeInfo);
+else
+    titleText = planeInfo;
+end
+
+% Set the title with the combined text
+title(axesHandle, titleText, 'FontSize', defaultFontSize, 'Color', matRad_cfg.gui.highlightColor);
 
 %Apply coloring
 set(axesHandle,'XColor',matRad_cfg.gui.textColor,'YColor',matRad_cfg.gui.textColor);
 
 end
+
 

--- a/matRad/util/matRad_plotSliceWrapper.m
+++ b/matRad/util/matRad_plotSliceWrapper.m
@@ -1,5 +1,5 @@
 function [hCMap,hDose,hCt,hContour,hIsoDose] = matRad_plotSliceWrapper(axesHandle,ct,cst,cubeIdx,dose,plane,slice,thresh,alpha,contourColorMap,...
-                                                                          doseColorMap,doseWindow,doseIsoLevels,voiSelection,colorBarLabel,boolPlotLegend,varargin)
+                                                                          doseColorMap,doseWindow,doseIsoLevels,voiSelection,colorBarLabel,boolPlotLegend,titleString,varargin)
 % matRad tool function to directly plot a complete slice of a ct with dose
 % including contours and isolines.
 %
@@ -13,7 +13,7 @@ function [hCMap,hDose,hCt,hContour,hIsoDose] = matRad_plotSliceWrapper(axesHandl
 % [hCMap,hDose,hCt,hContour,hIsoDose] = matRad_plotSliceWrapper(axesHandle,ct,cst,cubeIdx,dose,plane,slice,doseIsoLevels)
 %               ...
 % [hCMap,hDose,hCt,hContour,hIsoDose] = matRad_plotSliceWrapper(axesHandle,ct,cst,cubeIdx,dose,plane,slice,thresh,alpha,contourColorMap,...
-%                                                                          doseColorMap,doseWindow,doseIsoLevels,voiSelection,colorBarLabel,boolPlotLegend,...)
+%                                                                          doseColorMap,doseWindow,doseIsoLevels,voiSelection,colorBarLabel,boolPlotLegend,titleString,...)
 %
 % input (required)
 %   axesHandle      handle to axes the slice should be displayed in
@@ -36,6 +36,7 @@ function [hCMap,hDose,hCt,hContour,hIsoDose] = matRad_plotSliceWrapper(axesHandl
 %                   all non-ignored contours.
 %   colorBarLabel   string defining the yLabel of the colorBar
 %   boolPlotLegend  boolean if legend should be plottet or not
+%   titleString     string to display as title for the plot
 %   varargin        additional input parameters that are passed on to
 %                   individual plotting functions (e.g. 'LineWidth',1.5)
 %   
@@ -99,6 +100,10 @@ if ~exist('cst','var') || isempty(cst)
    cst = [];
 end
 
+if ~exist('titleString','var') || isempty(titleString)
+   titleString = [];
+end
+
 matRad_cfg = MatRad_Config.instance();
 
 set(axesHandle,'YDir','Reverse');
@@ -148,10 +153,10 @@ axis(axesHandle,'tight');
 set(axesHandle,'xtick',[],'ytick',[]);
 colormap(axesHandle,doseColorMap);
 
-matRad_plotAxisLabels(axesHandle,ct,plane,slice,[])
+% Add axis labels with plane information and title
+matRad_plotAxisLabels(axesHandle,ct,plane,slice,[],titleString)
 
 % set axis ratio
-
 ratios = [1/ct.resolution.x 1/ct.resolution.y 1/ct.resolution.z];
    
 set(axesHandle,'DataAspectRatioMode','manual');
@@ -170,6 +175,11 @@ hCMap = matRad_plotColorbar(axesHandle,doseColorMap,doseWindow,'Location','EastO
 set(hCMap,'Color',matRad_cfg.gui.textColor);
 if ~isempty(colorBarLabel)
     set(get(hCMap,'YLabel'),'String', colorBarLabel,'FontSize',matRad_cfg.gui.fontSize);
+end
+
+% Set the figure name as well if title is provided
+if ~isempty(titleString)   
+    set(ancestor(axesHandle, 'figure'), 'Name', titleString);
 end
 
 end


### PR DESCRIPTION
Hello :), so I wanted to instantiate pull requesting again with a minor fix now that I am working with matRad (actually, pyRadPlan) more often. I noticed that example2 tries to assign titles to the plotSliceWrapper, but they were getting masked by the axis settings.