### PR TITLE
Fix Octave Tests (Remove Incompatable Image package)

### DIFF
--- a/.github/before_install_linux.sh
+++ b/.github/before_install_linux.sh
@@ -7,4 +7,4 @@ mv matRad/optimization/optimizer/ipopt.m optimization/optimizer/ipopt.m.bak
 
 octave --no-gui --eval "pkg install -forge dicom"
 octave --no-gui --eval "pkg install -forge nan"
-octave --no-gui --eval "pkg install -forge image"
+octave --no-gui --eval "pkg install \"https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Individual%20Package%20Releases/image-2.14.0.tar.gz\""


### PR DESCRIPTION
Fixes the version of the image package for octave used in the tests to be compatible with Octave 6.