### PR TITLE
New Test Workflow Separation

### DIFF
--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -1,40 +1,58 @@
 name: Test Report
 
-permissions:
-    checks: write
-    pull-requests: write
-
 on:
-    workflow_call:
+    workflow_run:
+        workflows: ["Tests"]
+        types:
+            - completed
             
 jobs:
-    test_report:
+    test-report:
+        if: github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure'
         runs-on: ubuntu-latest
+        permissions:
+            checks: write
+            pull-requests: write
+
             
-        steps:
-            
+        steps:            
             - name: Download Results for Matlab R2022b
               uses: actions/download-artifact@v4
               with:
+                  run_id: ${{ github.event.workflow_run.id }}
                   name: test-results-matlab-R2022b
                   path: test-results/matlab-R2022b
             
             - name: Download Results for Matlab Latest
               uses: actions/download-artifact@v4
               with:
+                  run_id: ${{ github.event.workflow_run.id }}
                   name: test-results-matlab-latest
                   path: test-results/matlab-latest
             
             - name: Download Results for Octave
               uses: actions/download-artifact@v4
               with:
+                  run_id: ${{ github.event.workflow_run.id }}
                   name: test-results-octave
                   path: test-results/octave
-            
+
+            - name: Download Event File
+              uses: actions/download-artifact@v4
+              with:
+                  run_id: ${{ github.event.workflow_run.id }}
+                  name: event-file
+                  path: event-file
+
             - name: Publish Test Results
               uses: EnricoMi/publish-unit-test-result-action@v2
               with:
-                  files: |
-                      test-results/*/testresults.xml
+                  commit: ${{ github.event.workflow_run.head_sha }}
+                  files: "test-results/**/testresults.xml"
+                  event_file: event-file/event.json
+                  event_name: ${{ github.event.workflow_run.event}}
+                  comment_mode: ${{ (github.event.workflow_run.event == 'pull_request' || github.event_name == 'pull_request') && 'always' || 'off' }}
+                  check_name: "Test Results"
+
 
             

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,15 +38,19 @@ jobs:
         with:
           submodules: 'true'
       - uses: ./.github/actions/test-octave
-
-  test-report:
-    name: Collect Test Results
-    needs: [test-matlab-stable, test-matlab-latest, test-octave-6]
-    uses: ./.github/workflows/test-results.yml
-    secrets: inherit
   
   coverage-report:
     name: Collect Coverage Report
     needs: [test-matlab-stable]
     uses: ./.github/workflows/coverage-report.yml
     secrets: inherit
+
+  event_file:
+    name: Event File
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: event-file
+          path: ${{ github.event_path }}


### PR DESCRIPTION
Make test-results a workflow triggered on wofkrlow_run instead of workflow_call to enable PR comments for Forks