### PR TITLE
Fix GUI warnings and add missing GUI update in example 2

### DIFF
--- a/examples/matRad_example2_photons.m
+++ b/examples/matRad_example2_photons.m
@@ -182,13 +182,17 @@ pln.propStf.gantryAngles = [0:50:359];
 pln.propStf.couchAngles  = zeros(1,numel(pln.propStf.gantryAngles));
 pln.propStf.numOfBeams   = numel(pln.propStf.gantryAngles);
 
-
-
+%Let's rerun the dose calculation and optimization
 stf                      = matRad_generateStf(ct,cst,pln);
 pln.propStf.isoCenter    = vertcat(stf.isoCenter);
 dij                      = matRad_calcDoseInfluence(ct,cst,stf,pln);
 resultGUI_coarse         = matRad_fluenceOptimization(dij,cst,pln);
 
+%We append the new result to the resultGUI variable (recognized by the GUI)
+%using the identifier coarse
+resultGUI = matRad_appendResultGUI(resultGUI,resultGUI_coarse,false,'coarse');
+%A GUI update ensures the current values are updated
+matRadGUI;
 
 %%  Visual Comparison of results
 % Let's compare the new recalculation against the optimization result.

--- a/matRad/gui/widgets/matRad_WorkflowWidget.m
+++ b/matRad/gui/widgets/matRad_WorkflowWidget.m
@@ -278,7 +278,7 @@ classdef matRad_WorkflowWidget < matRad_Widget
                 set(handles.txtInfo,'String','loaded and ready');
                 
                 if evalin('base','exist(''pln'')')
-
+                    pln = evalin('base','pln');
                     
                     % ct cst and pln available; ready for dose calculation
                     set(handles.txtInfo,'String','ready for dose calculation');
@@ -287,9 +287,10 @@ classdef matRad_WorkflowWidget < matRad_Widget
                     set(handles.exportDicomButton,'Enable','on');
 
                     % check if stf exists
-                    if evalin('base','exist(''stf'')') 
+                    if evalin('base','exist(''stf'')')
+                        stf = evalin('base','stf');
                         % check if dij, stf and pln match
-                       [plnStfMatch, msg] = matRad_comparePlnStf(evalin('base','pln'),evalin('base','stf'));
+                       [plnStfMatch, msg] = matRad_comparePlnStf(pln,stf);
                         if plnStfMatch
                             % plan is ready for optimization
                             set(handles.txtInfo,'String','ready for dose calculation');
@@ -301,8 +302,11 @@ classdef matRad_WorkflowWidget < matRad_Widget
                         end
 
                         % check if dij exist
-                        if evalin('base','exist(''dij'')') && plnStfMatch && ~evalin('base','pln.propOpt.conf3D')
-                            [dijStfMatch, msg] = matRad_compareDijStf(evalin('base','dij'),evalin('base','stf'));
+                        conf3D = isfield(pln,'propOpt') && ~isfield(pln.propOpt,'conf3D') && pln.propOpt.conf3D;
+
+                        if evalin('base','exist(''dij'')') && plnStfMatch && ~conf3D
+                            dij = evalin('base','dij');
+                            [dijStfMatch, msg] = matRad_compareDijStf(dij,stf);
                             if dijStfMatch
                                 set(handles.txtInfo,'String','ready for optimization');
                                 set(handles.btnOptimize ,'Enable','on');
@@ -416,7 +420,7 @@ classdef matRad_WorkflowWidget < matRad_Widget
                 dij = matRad_calcDoseInfluence(evalin('base','ct'),evalin('base','cst'),stf,pln);
                 
                 % prepare dij for 3d conformal
-                if isfield(pln.propOpt,'conf3D') && pln.propOpt.conf3D
+                if isfield(pln,'propOpt') && ~isfield(pln.propOpt,'conf3D') && pln.propOpt.conf3D
                    dij = matRad_collapseDij(dij);
                 end
                 % assign results to base worksapce

--- a/matRad/gui/widgets/matRad_WorkflowWidget.m
+++ b/matRad/gui/widgets/matRad_WorkflowWidget.m
@@ -302,7 +302,7 @@ classdef matRad_WorkflowWidget < matRad_Widget
                         end
 
                         % check if dij exist
-                        conf3D = isfield(pln,'propOpt') && ~isfield(pln.propOpt,'conf3D') && pln.propOpt.conf3D;
+                        conf3D = isfield(pln,'propOpt') && isfield(pln.propOpt,'conf3D') && pln.propOpt.conf3D;
 
                         if evalin('base','exist(''dij'')') && plnStfMatch && ~conf3D
                             dij = evalin('base','dij');
@@ -420,7 +420,7 @@ classdef matRad_WorkflowWidget < matRad_Widget
                 dij = matRad_calcDoseInfluence(evalin('base','ct'),evalin('base','cst'),stf,pln);
                 
                 % prepare dij for 3d conformal
-                if isfield(pln,'propOpt') && ~isfield(pln.propOpt,'conf3D') && pln.propOpt.conf3D
+                if isfield(pln,'propOpt') && isfield(pln.propOpt,'conf3D') && pln.propOpt.conf3D
                    dij = matRad_collapseDij(dij);
                 end
                 % assign results to base worksapce

--- a/matRad/util/matRad_comparePlnStf.m
+++ b/matRad/util/matRad_comparePlnStf.m
@@ -46,18 +46,18 @@ if isfield(pln.propStf,'numOfBeams') && pln.propStf.numOfBeams ~= numel(stf)
 end
 
 %% compare gantry angles in  stf and pln
-stf_gantryAngles=[stf.gantryAngle];
-if ~isfield(pln.propStf,'gantryAngles') || numel(stf_gantryAngles) ~= numel(pln.propStf.gantryAngles) ... % different size
-        || ~isempty(find(stf_gantryAngles-pln.propStf.gantryAngles, 1))  % values in stf and pln do not match  % values in stf and pln do not match
+stfGantryAngles=[stf.gantryAngle];
+if ~isfield(pln.propStf,'gantryAngles') || numel(stfGantryAngles) ~= numel(pln.propStf.gantryAngles) ... % different size
+        || ~isempty(find(stfGantryAngles-pln.propStf.gantryAngles, 1))  % values in stf and pln do not match  % values in stf and pln do not match
     allMatch=false;
     msg= 'Gantry angles do not match';
     return
 end
 
 %% compare couch angles in stf and pln
-stf_couchAngles=[stf.couchAngle];
-if ~isfield(pln.propStf,'couchAngles') || numel(stf_couchAngles) ~= numel(pln.propStf.couchAngles) ... % different size
-        || ~isempty(find(stf_couchAngles-pln.propStf.couchAngles, 1))  % values in stf and pln do not match
+stfCouchAngles=[stf.couchAngle];
+if ~isfield(pln.propStf,'couchAngles') || numel(stfCouchAngles) ~= numel(pln.propStf.couchAngles) ... % different size
+        || ~isempty(find(stfCouchAngles-pln.propStf.couchAngles, 1))  % values in stf and pln do not match
     allMatch=false;
     msg= 'Couch angles do not match';
     return
@@ -88,7 +88,12 @@ end
 
 %% compare isocenter in stf and pln for each gantry angle
 for i = 1:numel(pln.propStf.gantryAngles)
-    if ~isempty(find(stf(i).isoCenter - pln.propStf.isoCenter(i,:) ,1))
+    if size(pln.propStf.isoCenter,1) == 1
+        isoCenter = repmat(pln.propStf.isoCenter,numel(stf),1);
+    else
+        isoCenter = pln.propStf.isoCenter;
+    end
+    if size(isoCenter,1) ~= numel(stf) || any(stf(i).isoCenter - isoCenter(i,:) ~= 0)
         allMatch=false;
         msg= 'Isocenters do not match';
         return


### PR DESCRIPTION
#856 identifies a missing GUI update in example 2, which was added in this PR.

Additionally, two bugs concerning a missing conf3D flag as well as a mistake in the pln/stf comparison were fixed.