### PR TITLE
Fix for overwriting isocenter with NaN from the GUI when multiple isocenters are defined

### DIFF
--- a/matRad/gui/widgets/matRad_PlanWidget.m
+++ b/matRad/gui/widgets/matRad_PlanWidget.m
@@ -970,9 +970,9 @@ classdef matRad_PlanWidget < matRad_Widget
                 pln.propStf.gantryAngles    = this.parseStringAsNum(get(handles.editGantryAngle,'String'),true); % [°]
                 pln.propStf.couchAngles     = this.parseStringAsNum(get(handles.editCouchAngle,'String'),true); % [°]
 
-                objectTag = get(hObject,'Tag');
+                objectTag = get(hObject,'Tag'); % Returns empty if hObject is empty, no check required
 
-                if ~isempty(hObject) && (strcmp(objectTag,'editGantryAngle')||strcmp(objectTag,'editCouchAngle'))
+                if ~isempty(objectTag) && (strcmp(objectTag,'editGantryAngle')||strcmp(objectTag,'editCouchAngle'))
                     if numel(this.parseStringAsNum(get(handles.editCouchAngle,'String'),true))<numel(this.parseStringAsNum(get(handles.editGantryAngle,'String'),true)) % Feature: autofill couch angles to single plane by entering a single value
                         couchGantryDifference = numel(this.parseStringAsNum(get(handles.editGantryAngle,'String'),true))-numel(this.parseStringAsNum(get(handles.editCouchAngle,'String'),true));
                         pln.propStf.couchAngles     = [this.parseStringAsNum(get(handles.editCouchAngle,'String'),true) zeros(1,couchGantryDifference)];

--- a/matRad/gui/widgets/matRad_PlanWidget.m
+++ b/matRad/gui/widgets/matRad_PlanWidget.m
@@ -982,8 +982,12 @@ classdef matRad_PlanWidget < matRad_Widget
                 this.plotPlan = true;
             end
 
-            pln.propStf.numOfBeams      = numel(pln.propStf.gantryAngles);
-            pln.propStf.isoCenter       = this.parseStringAsNum(get(handles.editIsoCenter,'String'),true);
+            pln.propStf.numOfBeams = numel(pln.propStf.gantryAngles);
+
+            isoStr = get(handles.editIsoCenter,'String');
+            if ~isequal(isoStr,'multiple isoCenter')
+                pln.propStf.isoCenter = this.parseStringAsNum(isoStr,true);
+            end
 
             % switch machines depending on radmode selection
             selectedMachine                     = get(handles.popUpMachine,'Value');

--- a/matRad/gui/widgets/matRad_PlanWidget.m
+++ b/matRad/gui/widgets/matRad_PlanWidget.m
@@ -970,7 +970,9 @@ classdef matRad_PlanWidget < matRad_Widget
                 pln.propStf.gantryAngles    = this.parseStringAsNum(get(handles.editGantryAngle,'String'),true); % [°]
                 pln.propStf.couchAngles     = this.parseStringAsNum(get(handles.editCouchAngle,'String'),true); % [°]
 
-                if ~isempty(hObject) && (strcmp(hObject.Tag,'editGantryAngle')||strcmp(hObject.Tag,'editCouchAngle'))
+                objectTag = get(hObject,'Tag');
+
+                if ~isempty(hObject) && (strcmp(objectTag,'editGantryAngle')||strcmp(objectTag,'editCouchAngle'))
                     if numel(this.parseStringAsNum(get(handles.editCouchAngle,'String'),true))<numel(this.parseStringAsNum(get(handles.editGantryAngle,'String'),true)) % Feature: autofill couch angles to single plane by entering a single value
                         couchGantryDifference = numel(this.parseStringAsNum(get(handles.editGantryAngle,'String'),true))-numel(this.parseStringAsNum(get(handles.editCouchAngle,'String'),true));
                         pln.propStf.couchAngles     = [this.parseStringAsNum(get(handles.editCouchAngle,'String'),true) zeros(1,couchGantryDifference)];

--- a/test/gui/test_gui_PlanWidget.m
+++ b/test/gui/test_gui_PlanWidget.m
@@ -110,5 +110,34 @@ function test_PlanWidget_constructWithHeliumPln
     evalin('base','clear ct cst pln stf dij resultGUI');
     delete(h);
 
+function test_PlanWidget_multiisocenter
+    evalin('base','load protons_testData.mat');
+    
+    %Modify to have multiple isocenters
+    pln = evalin('base','pln');
+    pln.propStf.isoCenter(2,:) = [0 0 0];
+    iso = pln.propStf.isoCenter;
+    assignin('base','pln',pln);
+
+    h = matRad_PlanWidget();
+
+    % check correct value in isocenter edit field
+    str = get(h.handles.editIsoCenter,'String');
+    assertEqual(str,'multiple isoCenter'); 
+
+    %Now force an update by changing a value and executing the callback
+    set(h.handles.editBixelWidth,'String','1');
+    cb = get(h.handles.editBixelWidth,'Callback');
+    cb(h.handles.editBixelWidth,[]);
+    
+    str = get(h.handles.editIsoCenter,'String');
+    assertEqual(str,'multiple isoCenter'); 
+    pln = evalin('base','pln');        
+    assertEqual(pln.propStf.isoCenter,iso);
+
+    evalin('base','clear ct cst pln stf dij resultGUI');
+    delete(h);
+
+
 
 %TODO: Test Buttons


### PR DESCRIPTION
Bug report #867 highlighted that, when `pln.propStf.isoCenter` contains multiple, differing isocenters, updates in the PlanWidget will parse the textbox value ("multiple isoCenters") incorrectly and assign NaN to  `pln.propStf.isoCenter`.

This PR introduces:
- A test to capture and reproduce this scenario
- A check for the string value in case of multiple isocenters, avoiding overwriting of the field
- An additional cleanup restoring octave compatibility of PlanWidget field changes

Fixes #867 