### PR TITLE
to prevent the matRadGUI window beeing to big if used in MATLAB Online

### DIFF
--- a/matRad/gui/matRad_MainGUI.m
+++ b/matRad/gui/matRad_MainGUI.m
@@ -210,6 +210,9 @@ classdef matRad_MainGUI < handle
             if matRad_ispropCompat(obj.guiHandle,'WindowState')
                 set(obj.guiHandle,'WindowState','maximized');
             end
+            if  matRad_cfg.isMatlab && isunix
+                movegui(obj.guiHandle,'onscreen');
+            end
 
             if matRad_cfg.isOctave
                 commonPanelProperties = {'Parent',obj.guiHandle,...


### PR DESCRIPTION
In MATLAB ONLINE the gui window was to large

added a switch to check if it is called from matlab online or not, the easiest way to check this is with isunix as matlab online runs with unix. Without this switch the initial GUI window can be a little bit smaller than fullscreen when run from matlab Desktop