### PR TITLE
Fix Intel Mac build for R2025b and update actions

### DIFF
--- a/.github/actions/test-matlab/action.yml
+++ b/.github/actions/test-matlab/action.yml
@@ -12,14 +12,14 @@ runs:
   steps:       
     # Install MATLAB
     - name: Install MATLAB
-      uses: matlab-actions/setup-matlab@v2
+      uses: matlab-actions/setup-matlab@v3
       with:
         release: ${{ inputs.matlab-version }}
         products: Image_Processing_Toolbox Parallel_Computing_Toolbox Optimization_Toolbox Global_Optimization_Toolbox
 
     # Runs test command
     - name: Run Tests
-      uses: matlab-actions/run-command@v2
+      uses: matlab-actions/run-command@v3
       with:
         command: matRad_runTests('test',true);
     

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -58,13 +58,13 @@ jobs:
           fi
 
       - name: Install MATLAB with Compiler
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@v3
         with:
-          release: latest
+          release: ${{ matrix.platform == 'macos-intel' && 'R2025b' || 'latest' }}
           products: MATLAB_Compiler MATLAB_Compiler_SDK Image_Processing_Toolbox Parallel_Computing_Toolbox Optimization_Toolbox Global_Optimization_Toolbox
 
       - name: Build Standalone
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@v3
         with:
           command: |
             matRad_buildStandalone('isRelease',${{ steps.build-type.outputs.is_release }},'verbose',true,'json','build_result.json')


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use the latest major version (`v3`) of the MATLAB Actions, ensuring compatibility and access to new features and bug fixes. The changes affect both the custom action and the main workflow for packaging.

**GitHub Actions version updates:**

* Updated the `matlab-actions/setup-matlab` and `matlab-actions/run-command` actions from `v2` to `v3` in both `.github/actions/test-matlab/action.yml` and `.github/workflows/package.yml`, ensuring the workflows use the latest supported versions. [[1]](diffhunk://#diff-4938fec285a84f4140c39352679c4756033294c3f056a90aef542cd07644c916L15-R22) [[2]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L61-R67)

**Workflow improvements:**

* Modified the MATLAB release selection in the `package.yml` workflow to use `R2025b` for `macos-intel` and `latest` for other platforms, improving platform-specific compatibility.